### PR TITLE
add minimap module

### DIFF
--- a/Modules/Minimap/Minimap.lua
+++ b/Modules/Minimap/Minimap.lua
@@ -1,0 +1,548 @@
+local TavernUI = LibStub("AceAddon-3.0"):GetAddon("TavernUI")
+local module = TavernUI:NewModule("Minimap", "AceEvent-3.0")
+
+local defaults = {
+    shape = "SQUARE",
+    size = 180,
+    scale = 1.0,
+    lock = false,
+    position = nil,
+    strata = "BACKGROUND",
+    opacity = 1.0,
+    opacityMoving = 1.0,
+    opacityMounted = 1.0,
+
+    borderSize = 3,
+    borderColor = {r=0, g=0, b=0, a=1},
+    useClassColorBorder = false,
+
+    mouseWheelZoom = true,
+    autoZoomOut = true,
+
+    showZoneText = true,
+    zoneText = {
+        position = "TOP", font = "", fadeOut = false,
+        fontSize = 12, offsetX = 0, offsetY = -2,
+        allCaps = true, useClassColor = false,
+        colorSanctuary = {r=0.41, g=0.80, b=0.94, a=1},
+        colorArena     = {r=1.00, g=0.10, b=0.10, a=1},
+        colorFriendly  = {r=0.10, g=1.00, b=0.10, a=1},
+        colorHostile   = {r=1.00, g=0.10, b=0.10, a=1},
+        colorContested = {r=1.00, g=0.70, b=0.00, a=1},
+        colorNormal    = {r=1.00, g=0.82, b=0.00, a=1},
+    },
+
+    showCoords = true,
+    coords = {
+        position = "TOPRIGHT", font = "", fadeOut = false,
+        fontSize = 12, precision = "%.1f, %.1f",
+        updateInterval = 1, offsetX = -2, offsetY = -2,
+        useClassColor = false, color = {r=1, g=1, b=1, a=1},
+    },
+
+    showClock = true,
+    clock = {
+        position = "TOPLEFT", font = "", fadeOut = false,
+        fontSize = 12, timeSource = "local", use24Hour = true,
+        offsetX = 2, offsetY = -2,
+        useClassColor = false, color = {r=1, g=1, b=1, a=1},
+    },
+
+    buttons = {
+        zoom             = { show = false, scale = 1.0, strata = "MEDIUM", point = "BOTTOMRIGHT", offsetX = 0, offsetY = 0, fadeOut = false },
+        mail             = { show = true,  scale = 1.0, strata = "MEDIUM", point = "BOTTOMLEFT",  offsetX = 0, offsetY = 0, fadeOut = false },
+        craftingOrder    = { show = true,  scale = 1.0, strata = "MEDIUM", point = "BOTTOMRIGHT", offsetX = 0, offsetY = 0, fadeOut = false },
+        addonCompartment = { show = false, scale = 1.0, strata = "MEDIUM", point = "TOPRIGHT",    offsetX = 0, offsetY = 0, fadeOut = false },
+        difficulty       = { show = true,  scale = 1.0, strata = "MEDIUM", point = "TOPLEFT",     offsetX = 0, offsetY = 0, fadeOut = false },
+        missions         = { show = false, scale = 1.0, strata = "MEDIUM", point = "TOPLEFT",     offsetX = 0, offsetY = 0, fadeOut = false },
+        calendar         = { show = false, scale = 1.0, strata = "MEDIUM", point = "TOPRIGHT",    offsetX = 0, offsetY = 0, fadeOut = false },
+        tracking         = { show = true,  scale = 1.0, strata = "MEDIUM", point = "TOPLEFT",     offsetX = 0, offsetY = 0, fadeOut = false },
+    },
+    hideAddonButtons = false,
+
+    dungeonEye = {
+        enabled = true, corner = "BOTTOMRIGHT",
+        scale = 0.8, offsetX = 0, offsetY = 0,
+    },
+}
+
+TavernUI:RegisterModuleDefaults("Minimap", defaults, true)
+
+--------------------------------------------------------------------------------
+-- File-scope: Layout workaround, hidden parent, zoom button hooks
+--------------------------------------------------------------------------------
+
+local hiddenParent = CreateFrame("Frame")
+hiddenParent:Hide()
+hiddenParent.Layout = function() end
+
+local function EnsureLayout(frame)
+    if frame and not frame.Layout then
+        frame.Layout = function() end
+    end
+end
+
+EnsureLayout(Minimap)
+if MinimapCluster and MinimapCluster.IndicatorFrame then
+    EnsureLayout(MinimapCluster.IndicatorFrame)
+end
+
+-- HybridMinimap handler
+local hybridFrame = CreateFrame("Frame")
+hybridFrame:RegisterEvent("ADDON_LOADED")
+hybridFrame:SetScript("OnEvent", function(_, _, addonName)
+    if addonName == "Blizzard_HybridMinimap" then
+        local mod = TavernUI:GetModule("Minimap", true)
+        if mod and mod:IsEnabled() and mod._setupDone then
+            mod:SetShape()
+        end
+    end
+end)
+
+--------------------------------------------------------------------------------
+-- Lifecycle
+--------------------------------------------------------------------------------
+
+function module:OnInitialize()
+    self:RegisterMessage("TavernUI_ProfileChanged", "OnProfileChanged")
+    self:WatchSetting("coords.updateInterval", function()
+        if self.Elements and self.Elements.RefreshCoordsTicker then
+            self.Elements.RefreshCoordsTicker()
+        end
+    end)
+end
+
+function module:OnEnable()
+    C_Timer.After(0.5, function()
+        if self:IsEnabled() then
+            self:SetupMinimap()
+        end
+    end)
+end
+
+function module:OnDisable()
+    self:StopTickers()
+end
+
+function module:OnProfileChanged()
+    if self:IsEnabled() and self._setupDone then
+        self:RefreshAll()
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Setup
+--------------------------------------------------------------------------------
+
+function module:SetupMinimap()
+    if self._setupDone then
+        self:RefreshAll()
+        return
+    end
+    self._setupDone = true
+
+    self:HideBlizzardDecorations()
+    self:SetShape()
+    self:CreateBackdrop()
+    self:UpdateSize()
+    self:SetupDragging()
+    self:UpdatePosition()
+    self:UpdateLock()
+    self:SetupMouseWheelZoom()
+    self:SetupAutoZoom()
+    self:UpdateStrata()
+    self:ApplyOpacity()
+    self:SetupOpacityEvents()
+
+    -- Delegate to Elements
+    if self.Elements then
+        self.Elements.Setup()
+    end
+
+    self:StartTickers()
+end
+
+function module:RefreshAll()
+    if not self._setupDone then return end
+
+    self:SetShape()
+    self:UpdateBackdrop()
+    self:UpdateSize()
+    self:UpdatePosition()
+    self:UpdateLock()
+    self:SetupMouseWheelZoom()
+    self:SetupAutoZoom()
+    self:UpdateStrata()
+    self:ApplyOpacity()
+
+    if self.Elements then
+        self.Elements.RefreshAll()
+    end
+
+    self:RestartTickers()
+end
+
+--------------------------------------------------------------------------------
+-- Tickers
+--------------------------------------------------------------------------------
+
+function module:StartTickers()
+    if self.Elements and self.Elements.StartTickers then
+        self.Elements.StartTickers()
+    end
+end
+
+function module:StopTickers()
+    if self.Elements and self.Elements.StopTickers then
+        self.Elements.StopTickers()
+    end
+end
+
+function module:RestartTickers()
+    self:StopTickers()
+    self:StartTickers()
+end
+
+--------------------------------------------------------------------------------
+-- Shape
+--------------------------------------------------------------------------------
+
+local SQUARE_MASK = "Interface\\ChatFrame\\ChatFrameBackground"
+local ROUND_MASK  = "Interface\\CHARACTERFRAME\\TempPortraitAlphaMask"
+
+function module:SetShape()
+    local shape = self:GetSetting("shape", "SQUARE")
+
+    if shape == "SQUARE" then
+        Minimap:SetMaskTexture(SQUARE_MASK)
+        _G.GetMinimapShape = function() return "SQUARE" end
+    else
+        Minimap:SetMaskTexture(ROUND_MASK)
+        _G.GetMinimapShape = function() return "ROUND" end
+    end
+
+    -- HybridMinimap
+    if HybridMinimap and HybridMinimap.MapCanvas then
+        if shape == "SQUARE" then
+            HybridMinimap.MapCanvas:SetMaskTexture(SQUARE_MASK)
+        else
+            HybridMinimap.MapCanvas:SetMaskTexture(ROUND_MASK)
+        end
+    end
+
+    -- Suppress blob ring for square
+    if shape == "SQUARE" then
+        if Minimap.SetArchBlobRingScalar then
+            Minimap:SetArchBlobRingScalar(0)
+        end
+        if Minimap.SetQuestBlobRingScalar then
+            Minimap:SetQuestBlobRingScalar(0)
+        end
+    else
+        if Minimap.SetArchBlobRingScalar then
+            Minimap:SetArchBlobRingScalar(1)
+        end
+        if Minimap.SetQuestBlobRingScalar then
+            Minimap:SetQuestBlobRingScalar(1)
+        end
+    end
+
+    -- Update backdrop mask
+    if self.backdropFrame then
+        self:UpdateBackdrop()
+    end
+
+    -- Refresh LibDBIcon if available
+    local LDBIcon = LibStub("LibDBIcon-1.0", true)
+    if LDBIcon then
+        pcall(function() LDBIcon:Refresh() end)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Backdrop / Border
+--------------------------------------------------------------------------------
+
+function module:CreateBackdrop()
+    if self.backdropFrame then return end
+
+    local f = CreateFrame("Frame", "TavernUI_MinimapBackdrop", Minimap, "BackdropTemplate")
+    f:SetFrameStrata("BACKGROUND")
+    f:SetFrameLevel(0)
+    self.backdropFrame = f
+
+    self:UpdateBackdrop()
+end
+
+function module:UpdateBackdrop()
+    local f = self.backdropFrame
+    if not f then return end
+
+    local borderSize = self:GetSetting("borderSize", 3)
+    local borderColor = self:GetSetting("borderColor", {r=0, g=0, b=0, a=1})
+    local useClassColor = self:GetSetting("useClassColorBorder", false)
+    local shape = self:GetSetting("shape", "SQUARE")
+
+    f:ClearAllPoints()
+    f:SetPoint("TOPLEFT", Minimap, "TOPLEFT", -borderSize, borderSize)
+    f:SetPoint("BOTTOMRIGHT", Minimap, "BOTTOMRIGHT", borderSize, -borderSize)
+
+    if borderSize > 0 then
+        local r, g, b, a
+        if useClassColor then
+            local _, class = UnitClass("player")
+            local color = RAID_CLASS_COLORS[class]
+            if color then
+                r, g, b, a = color.r, color.g, color.b, 1
+            else
+                r, g, b, a = 1, 1, 1, 1  -- fallback to white
+            end
+        else
+            r = borderColor.r or 0
+            g = borderColor.g or 0
+            b = borderColor.b or 0
+            a = borderColor.a or 1
+        end
+
+        if shape == "SQUARE" then
+            f:SetBackdrop({
+                edgeFile = "Interface\\ChatFrame\\ChatFrameBackground",
+                edgeSize = borderSize,
+            })
+            f:SetBackdropBorderColor(r, g, b, a)
+            if f.roundBorder then f.roundBorder:Hide() end
+        else
+            f:SetBackdrop(nil)
+            if not f.roundBorder then
+                f.roundBorder = f:CreateTexture(nil, "BACKGROUND")
+                f.roundBorder:SetAllPoints(f)
+                local mask = f:CreateMaskTexture()
+                mask:SetAllPoints(f)
+                mask:SetTexture(ROUND_MASK)
+                f.roundBorder:AddMaskTexture(mask)
+            end
+            f.roundBorder:SetColorTexture(r, g, b, a)
+            f.roundBorder:Show()
+        end
+        f:Show()
+    else
+        f:SetBackdrop(nil)
+        if f.roundBorder then f.roundBorder:Hide() end
+        f:Hide()
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Size
+--------------------------------------------------------------------------------
+
+function module:UpdateSize()
+    local size = self:GetSetting("size", 180)
+    local scale = self:GetSetting("scale", 1.0)
+
+    Minimap:SetSize(size, size)
+    MinimapCluster:SetScale(scale)
+
+    -- Force render update via zoom toggle trick
+    local currentZoom = Minimap:GetZoom()
+    if currentZoom > 0 then
+        Minimap:SetZoom(currentZoom - 1)
+        Minimap:SetZoom(currentZoom)
+    else
+        Minimap:SetZoom(1)
+        Minimap:SetZoom(0)
+    end
+
+    -- Update LibDBIcon button radius
+    local LDBIcon = LibStub("LibDBIcon-1.0", true)
+    if LDBIcon then
+        pcall(function() LDBIcon:Refresh() end)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Dragging / Position
+--------------------------------------------------------------------------------
+
+function module:SetupDragging()
+    if self._dragSetup then return end
+    self._dragSetup = true
+
+    Minimap:SetMovable(true)
+    Minimap:SetClampedToScreen(true)
+
+    -- Reparent minimap to UIParent so it's freely movable
+    Minimap:SetParent(UIParent)
+
+    Minimap:RegisterForDrag("LeftButton")
+    Minimap:SetScript("OnDragStart", function(frame)
+        if not module:GetSetting("lock", false) then
+            frame:StartMoving()
+        end
+    end)
+    Minimap:SetScript("OnDragStop", function(frame)
+        frame:StopMovingOrSizing()
+        local point, _, relPoint, x, y = frame:GetPoint()
+        module:SetSetting("position", {point = point, relPoint = relPoint, x = x, y = y})
+    end)
+end
+
+function module:UpdatePosition()
+    local pos = self:GetSetting("position")
+    if pos and pos.point then
+        Minimap:ClearAllPoints()
+        Minimap:SetPoint(pos.point, UIParent, pos.relPoint, pos.x, pos.y)
+    else
+        Minimap:ClearAllPoints()
+        Minimap:SetPoint("TOPRIGHT", UIParent, "TOPRIGHT", -10, -10)
+    end
+end
+
+function module:UpdateLock()
+    local locked = self:GetSetting("lock", false)
+    Minimap:SetMovable(not locked)
+end
+
+--------------------------------------------------------------------------------
+-- Mouse Wheel Zoom
+--------------------------------------------------------------------------------
+
+function module:SetupMouseWheelZoom()
+    local enabled = self:GetSetting("mouseWheelZoom", true)
+    if enabled then
+        Minimap:EnableMouseWheel(true)
+        Minimap:SetScript("OnMouseWheel", function(_, delta)
+            local zoom = Minimap:GetZoom()
+            if delta > 0 then
+                if zoom < Minimap:GetZoomLevels() then
+                    Minimap:SetZoom(zoom + 1)
+                end
+            else
+                if zoom > 0 then
+                    Minimap:SetZoom(zoom - 1)
+                end
+            end
+        end)
+    else
+        Minimap:EnableMouseWheel(false)
+        Minimap:SetScript("OnMouseWheel", nil)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Auto Zoom Out
+--------------------------------------------------------------------------------
+
+function module:SetupAutoZoom()
+    local enabled = self:GetSetting("autoZoomOut", true)
+
+    if enabled and not self._autoZoomHooked then
+        self._autoZoomHooked = true
+        local zoomTimer
+        hooksecurefunc(Minimap, "SetZoom", function()
+            if not module:GetSetting("autoZoomOut", true) then
+                return
+            end
+            if zoomTimer then
+                zoomTimer:Cancel()
+            end
+            local zoom = Minimap:GetZoom()
+            if zoom > 0 then
+                zoomTimer = C_Timer.NewTimer(15, function()
+                    if Minimap:GetZoom() > 0 then
+                        Minimap:SetZoom(0)
+                    end
+                end)
+            end
+        end)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Strata & Dynamic Opacity
+--------------------------------------------------------------------------------
+
+function module:UpdateStrata()
+    local strata = self:GetSetting("strata", "BACKGROUND")
+    Minimap:SetFrameStrata(strata)
+    if self.backdropFrame then
+        self.backdropFrame:SetFrameStrata(strata)
+        self.backdropFrame:SetFrameLevel(0)
+    end
+end
+
+function module:ApplyOpacity()
+    local alpha
+    if IsMounted() then
+        alpha = self:GetSetting("opacityMounted", 1.0)
+    elseif self._isMoving then
+        alpha = self:GetSetting("opacityMoving", 1.0)
+    else
+        alpha = self:GetSetting("opacity", 1.0)
+    end
+
+    Minimap:SetAlpha(alpha)
+    if self.backdropFrame then
+        self.backdropFrame:SetAlpha(alpha)
+    end
+end
+
+function module:SetupOpacityEvents()
+    if self._opacityEventsRegistered then return end
+    self._opacityEventsRegistered = true
+
+    self:RegisterEvent("PLAYER_STARTED_MOVING", function()
+        self._isMoving = true
+        self:ApplyOpacity()
+    end)
+    self:RegisterEvent("PLAYER_STOPPED_MOVING", function()
+        self._isMoving = false
+        self:ApplyOpacity()
+    end)
+    self:RegisterEvent("PLAYER_MOUNT_DISPLAY_CHANGED", function()
+        self:ApplyOpacity()
+    end)
+end
+
+--------------------------------------------------------------------------------
+-- Hide Blizzard Decorations
+--------------------------------------------------------------------------------
+
+function module:HideBlizzardDecorations()
+    -- Hide MinimapCluster sub-frames we don't need
+    local framesToHide = {
+        MinimapBackdrop,
+        MinimapBorder,
+        MinimapBorderTop,
+        MinimapNorthTag,
+        MinimapCompassTexture,
+    }
+
+    for _, frame in ipairs(framesToHide) do
+        if frame then
+            if frame.Hide then frame:Hide() end
+            if frame.SetAlpha then frame:SetAlpha(0) end
+        end
+    end
+
+    -- Hide edge textures on Minimap itself
+    if Minimap.EdgeTextures then
+        for _, tex in ipairs(Minimap.EdgeTextures) do
+            if tex and tex.Hide then tex:Hide() end
+        end
+    end
+
+    -- Hide the cluster header bar
+    if MinimapCluster then
+        if MinimapCluster.BorderTop then
+            MinimapCluster.BorderTop:Hide()
+            MinimapCluster.BorderTop:SetAlpha(0)
+        end
+        if MinimapCluster.Background then
+            MinimapCluster.Background:Hide()
+            MinimapCluster.Background:SetAlpha(0)
+        end
+    end
+
+    -- Zoom button visibility is handled by Elements.UpdateButtonVisibility()
+end

--- a/Modules/Minimap/Minimap.xml
+++ b/Modules/Minimap/Minimap.xml
@@ -1,0 +1,10 @@
+<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
+    <!-- Core module -->
+    <Script file="Minimap.lua"/>
+
+    <!-- Element subsystems -->
+    <Script file="Minimap_Elements.lua"/>
+
+    <!-- Options panel -->
+    <Script file="Minimap_Options.lua"/>
+</Ui>

--- a/Modules/Minimap/Minimap_Elements.lua
+++ b/Modules/Minimap/Minimap_Elements.lua
@@ -1,0 +1,742 @@
+local TavernUI = LibStub("AceAddon-3.0"):GetAddon("TavernUI")
+local module = TavernUI:GetModule("Minimap", true)
+
+if not module then return end
+
+local Elements = {}
+module.Elements = Elements
+
+local FALLBACK_FONT = "Fonts\\FRIZQT__.TTF"
+
+local function GetFont(key)
+    return TavernUI:GetFontPath(key) or FALLBACK_FONT
+end
+
+local function SafeSetFont(fontString, key, size, flags)
+    if not fontString:SetFont(GetFont(key), size, flags) then
+        fontString:SetFont(FALLBACK_FONT, size, flags)
+    end
+end
+
+local clockTicker, coordsTicker
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+local function GetClassColor()
+    local _, class = UnitClass("player")
+    local color = RAID_CLASS_COLORS[class]
+    if not color then
+        return 1, 1, 1  -- fallback to white
+    end
+    return color.r, color.g, color.b
+end
+
+local function JustifyFromPoint(point)
+    if point:find("LEFT") then return "LEFT" end
+    if point:find("RIGHT") then return "RIGHT" end
+    return "CENTER"
+end
+
+local hiddenHolder = CreateFrame("Frame")
+hiddenHolder:Hide()
+hiddenHolder.Layout = function() end
+
+-- Button holder lives outside the Minimap widget hierarchy so that
+-- the Minimap's native mouse handling does not swallow clicks.
+local buttonHolder = CreateFrame("Frame", "TavernUI_MinimapButtonHolder", UIParent)
+buttonHolder:SetAllPoints(Minimap)
+buttonHolder:EnableMouse(false)
+
+local suppressedFrames = {}
+
+local function HideFrame(frame)
+    if not frame then return end
+    suppressedFrames[frame] = true
+    frame:SetParent(hiddenHolder)
+    frame:Hide()
+    if not frame.Layout then
+        frame.Layout = function() end
+    end
+    -- Hook Show once to prevent Blizzard layout from re-showing
+    if not frame._tavernShowHooked then
+        frame._tavernShowHooked = true
+        hooksecurefunc(frame, "Show", function(self)
+            if suppressedFrames[self] then
+                self:Hide()
+            end
+        end)
+    end
+end
+
+local function ShowFrame(frame, parent)
+    if not frame then return end
+    suppressedFrames[frame] = nil
+    frame:SetParent(parent or MinimapCluster)
+    frame:SetFrameLevel(Minimap:GetFrameLevel() + 10)
+    frame:Show()
+end
+
+--------------------------------------------------------------------------------
+-- Fade System
+--------------------------------------------------------------------------------
+
+local fadeableButtons = {}
+local isMinimapHovered = false
+local fadeCheckTimer = nil
+
+local function CheckMinimapHover()
+    if Minimap:IsMouseOver() then return true end
+    for frame in pairs(fadeableButtons) do
+        if frame:IsShown() and frame:IsMouseOver() then
+            return true
+        end
+    end
+    return false
+end
+
+local function ShowFadedButtons()
+    isMinimapHovered = true
+    if fadeCheckTimer then fadeCheckTimer:Cancel(); fadeCheckTimer = nil end
+    for frame in pairs(fadeableButtons) do
+        frame:SetAlpha(1)
+    end
+end
+
+local function StartFadeCheck()
+    if fadeCheckTimer then fadeCheckTimer:Cancel() end
+    fadeCheckTimer = C_Timer.NewTimer(0.3, function()
+        fadeCheckTimer = nil
+        if not CheckMinimapHover() then
+            isMinimapHovered = false
+            for frame in pairs(fadeableButtons) do
+                frame:SetAlpha(0)
+            end
+        end
+    end)
+end
+
+local function HookButtonFade(frame)
+    if not frame or frame._tavernFadeHooked then return end
+    frame._tavernFadeHooked = true
+    frame:HookScript("OnEnter", function()
+        if fadeableButtons[frame] then
+            ShowFadedButtons()
+        end
+    end)
+    frame:HookScript("OnLeave", function()
+        if fadeableButtons[frame] then
+            StartFadeCheck()
+        end
+    end)
+end
+
+local fadeHooksSetup = false
+local function SetupFadeHooks()
+    if fadeHooksSetup then return end
+    fadeHooksSetup = true
+    Minimap:HookScript("OnEnter", ShowFadedButtons)
+    Minimap:HookScript("OnLeave", StartFadeCheck)
+end
+
+--------------------------------------------------------------------------------
+-- Zone Text
+--------------------------------------------------------------------------------
+
+local zoneFrame, zoneText
+
+local function CreateZoneText()
+    if zoneFrame then return end
+
+    zoneFrame = CreateFrame("Frame", "TavernUI_MinimapZone", Minimap)
+    zoneFrame:SetSize(Minimap:GetWidth(), 20)
+    zoneFrame:SetPoint("TOP", Minimap, "TOP", 0, 0)
+
+    zoneText = zoneFrame:CreateFontString(nil, "OVERLAY")
+    zoneText:SetPoint("TOP", zoneFrame, "TOP", 0, 0)
+    zoneText:SetJustifyH("CENTER")
+
+    -- Tooltip
+    zoneFrame:EnableMouse(true)
+    zoneFrame:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_LEFT")
+        local zone = GetZoneText() or ""
+        local subZone = GetSubZoneText() or ""
+        GameTooltip:AddLine(zone, 1, 1, 1)
+        if subZone ~= "" and subZone ~= zone then
+            GameTooltip:AddLine(subZone, 0.7, 0.7, 0.7)
+        end
+        GameTooltip:Show()
+    end)
+    zoneFrame:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+end
+
+local function GetZoneColor()
+    local useClassColor = module:GetSetting("zoneText.useClassColor", false)
+    if useClassColor then
+        local r, g, b = GetClassColor()
+        return r, g, b
+    end
+
+    local pvpType = C_PvP.GetZonePVPInfo()
+    local colorKey
+    if pvpType == "sanctuary" then
+        colorKey = "colorSanctuary"
+    elseif pvpType == "arena" then
+        colorKey = "colorArena"
+    elseif pvpType == "friendly" then
+        colorKey = "colorFriendly"
+    elseif pvpType == "hostile" then
+        colorKey = "colorHostile"
+    elseif pvpType == "contested" then
+        colorKey = "colorContested"
+    else
+        colorKey = "colorNormal"
+    end
+
+    local c = module:GetSetting("zoneText." .. colorKey, {r=1, g=0.82, b=0, a=1})
+    return c.r or 1, c.g or 0.82, c.b or 0, c.a or 1
+end
+
+local function UpdateZoneText()
+    if not zoneFrame or not zoneText then return end
+
+    local show = module:GetSetting("showZoneText", true)
+    if not show then
+        zoneFrame:Hide()
+        return
+    end
+    zoneFrame:Show()
+
+    local position = module:GetSetting("zoneText.position", "TOP")
+    local fontKey = module:GetSetting("zoneText.font", "")
+    local fontSize = module:GetSetting("zoneText.fontSize", 12)
+    local offsetX = module:GetSetting("zoneText.offsetX", 0)
+    local offsetY = module:GetSetting("zoneText.offsetY", -2)
+    local allCaps = module:GetSetting("zoneText.allCaps", true)
+    local fadeOut = module:GetSetting("zoneText.fadeOut", false)
+
+    zoneFrame:ClearAllPoints()
+    zoneFrame:SetPoint(position, Minimap, position, 0, 0)
+    zoneFrame:SetWidth(Minimap:GetWidth())
+
+    local justify = JustifyFromPoint(position)
+    SafeSetFont(zoneText, fontKey, fontSize, "OUTLINE")
+    zoneText:SetJustifyH(justify)
+    zoneText:ClearAllPoints()
+    zoneText:SetPoint(position, zoneFrame, position, offsetX, offsetY)
+
+    local text = GetMinimapZoneText() or ""
+    if allCaps then
+        text = text:upper()
+    end
+    zoneText:SetText(text)
+
+    local r, g, b, a = GetZoneColor()
+    zoneText:SetTextColor(r, g, b, a)
+
+    if fadeOut then
+        SetupFadeHooks()
+        fadeableButtons[zoneFrame] = true
+        HookButtonFade(zoneFrame)
+        zoneFrame:SetAlpha(isMinimapHovered and 1 or 0)
+    else
+        fadeableButtons[zoneFrame] = nil
+        zoneFrame:SetAlpha(1)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Coordinates
+--------------------------------------------------------------------------------
+
+local coordsFrame, coordsText
+
+local function CreateCoords()
+    if coordsFrame then return end
+
+    coordsFrame = CreateFrame("Frame", "TavernUI_MinimapCoords", Minimap)
+    coordsFrame:SetSize(60, 16)
+
+    coordsText = coordsFrame:CreateFontString(nil, "OVERLAY")
+end
+
+local function UpdateCoords()
+    if not coordsFrame or not coordsText then return end
+
+    local show = module:GetSetting("showCoords", true)
+    if not show then
+        coordsFrame:Hide()
+        return
+    end
+    coordsFrame:Show()
+
+    local position = module:GetSetting("coords.position", "TOPRIGHT")
+    local fontKey = module:GetSetting("coords.font", "")
+    local fontSize = module:GetSetting("coords.fontSize", 12)
+    local offsetX = module:GetSetting("coords.offsetX", -2)
+    local offsetY = module:GetSetting("coords.offsetY", -2)
+    local precision = module:GetSetting("coords.precision", "%.1f, %.1f")
+    local useClassColor = module:GetSetting("coords.useClassColor", false)
+    local color = module:GetSetting("coords.color", {r=1, g=1, b=1, a=1})
+    local fadeOut = module:GetSetting("coords.fadeOut", false)
+
+    coordsFrame:ClearAllPoints()
+    coordsFrame:SetPoint(position, Minimap, position, 0, 0)
+
+    local justify = JustifyFromPoint(position)
+    SafeSetFont(coordsText, fontKey, fontSize, "OUTLINE")
+    coordsText:SetJustifyH(justify)
+    coordsText:ClearAllPoints()
+    coordsText:SetPoint(position, coordsFrame, position, offsetX, offsetY)
+
+    -- Get player coords
+    local x, y = 0, 0
+    local mapID = C_Map.GetBestMapForUnit("player")
+    if mapID then
+        local pos = C_Map.GetPlayerMapPosition(mapID, "player")
+        if pos then
+            x, y = pos:GetXY()
+            x = x * 100
+            y = y * 100
+        end
+    end
+
+    local success, formatted = pcall(string.format, precision, x, y)
+    coordsText:SetText(success and formatted or string.format("%.1f, %.1f", x, y))
+
+    if useClassColor then
+        local r, g, b = GetClassColor()
+        coordsText:SetTextColor(r, g, b)
+    else
+        coordsText:SetTextColor(color.r or 1, color.g or 1, color.b or 1, color.a or 1)
+    end
+
+    if fadeOut then
+        SetupFadeHooks()
+        fadeableButtons[coordsFrame] = true
+        HookButtonFade(coordsFrame)
+        coordsFrame:SetAlpha(isMinimapHovered and 1 or 0)
+    else
+        fadeableButtons[coordsFrame] = nil
+        coordsFrame:SetAlpha(1)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Clock
+--------------------------------------------------------------------------------
+
+local clockFrame, clockText
+
+local function CreateClock()
+    if clockFrame then return end
+
+    clockFrame = CreateFrame("Button", "TavernUI_MinimapClock", Minimap)
+    clockFrame:SetSize(50, 16)
+
+    clockText = clockFrame:CreateFontString(nil, "OVERLAY")
+
+    clockFrame:RegisterForClicks("LeftButtonUp", "RightButtonUp")
+    clockFrame:SetScript("OnClick", function(_, button)
+        if button == "LeftButton" then
+            if ToggleCalendar then
+                ToggleCalendar()
+            end
+        elseif button == "RightButton" then
+            if TimeManagerFrame then
+                if TimeManagerFrame:IsShown() then
+                    TimeManagerFrame:Hide()
+                else
+                    TimeManagerFrame:Show()
+                end
+            end
+        end
+    end)
+    clockFrame:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_LEFT")
+        GameTooltip:AddLine("Clock", 1, 1, 1)
+        GameTooltip:AddLine("Left-click: Calendar", 0.7, 0.7, 0.7)
+        GameTooltip:AddLine("Right-click: Stopwatch", 0.7, 0.7, 0.7)
+        GameTooltip:Show()
+    end)
+    clockFrame:SetScript("OnLeave", function()
+        GameTooltip:Hide()
+    end)
+
+    -- Hide Blizzard clock
+    if TimeManagerClockButton then
+        TimeManagerClockButton:Hide()
+    end
+end
+
+local function UpdateClock()
+    if not clockFrame or not clockText then return end
+
+    local show = module:GetSetting("showClock", true)
+    if not show then
+        clockFrame:Hide()
+        return
+    end
+    clockFrame:Show()
+
+    local position = module:GetSetting("clock.position", "TOPLEFT")
+    local fontKey = module:GetSetting("clock.font", "")
+    local fontSize = module:GetSetting("clock.fontSize", 12)
+    local offsetX = module:GetSetting("clock.offsetX", 2)
+    local offsetY = module:GetSetting("clock.offsetY", -2)
+    local timeSource = module:GetSetting("clock.timeSource", "local")
+    local use24Hour = module:GetSetting("clock.use24Hour", true)
+    local useClassColor = module:GetSetting("clock.useClassColor", false)
+    local color = module:GetSetting("clock.color", {r=1, g=1, b=1, a=1})
+    local fadeOut = module:GetSetting("clock.fadeOut", false)
+
+    clockFrame:ClearAllPoints()
+    clockFrame:SetPoint(position, Minimap, position, 0, 0)
+
+    local justify = JustifyFromPoint(position)
+    SafeSetFont(clockText, fontKey, fontSize, "OUTLINE")
+    clockText:SetJustifyH(justify)
+    clockText:ClearAllPoints()
+    clockText:SetPoint(position, clockFrame, position, offsetX, offsetY)
+
+    local hour, minute
+    if timeSource == "server" then
+        hour, minute = GetGameTime()
+    else
+        local dateTable = date("*t")
+        hour = dateTable.hour
+        minute = dateTable.min
+    end
+
+    local timeStr
+    if use24Hour then
+        timeStr = string.format("%02d:%02d", hour, minute)
+    else
+        local suffix = hour >= 12 and "PM" or "AM"
+        hour = hour % 12
+        if hour == 0 then hour = 12 end
+        timeStr = string.format("%d:%02d %s", hour, minute, suffix)
+    end
+
+    clockText:SetText(timeStr)
+
+    if useClassColor then
+        local r, g, b = GetClassColor()
+        clockText:SetTextColor(r, g, b)
+    else
+        clockText:SetTextColor(color.r or 1, color.g or 1, color.b or 1, color.a or 1)
+    end
+
+    if fadeOut then
+        SetupFadeHooks()
+        fadeableButtons[clockFrame] = true
+        HookButtonFade(clockFrame)
+        clockFrame:SetAlpha(isMinimapHovered and 1 or 0)
+    else
+        fadeableButtons[clockFrame] = nil
+        clockFrame:SetAlpha(1)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Button Visibility / Positioning / Fade
+--------------------------------------------------------------------------------
+
+-- Resolve a frame from multiple possible references (TWW changed many names)
+local function ResolveFrame(...)
+    for i = 1, select("#", ...) do
+        local frame = select(i, ...)
+        if frame then return frame end
+    end
+    return nil
+end
+
+-- Resolve all button frames once (called each update since addons can load late)
+local function GetButtonFrames()
+    return {
+        zoom = {
+            ResolveFrame(Minimap and Minimap.ZoomIn,  MinimapCluster and MinimapCluster.ZoomIn,  MinimapZoomIn),
+            ResolveFrame(Minimap and Minimap.ZoomOut, MinimapCluster and MinimapCluster.ZoomOut, MinimapZoomOut),
+        },
+        mail = ResolveFrame(
+            MinimapCluster and MinimapCluster.IndicatorFrame and MinimapCluster.IndicatorFrame.MailFrame,
+            MiniMapMailFrame
+        ),
+        craftingOrder = MinimapCluster and MinimapCluster.IndicatorFrame
+            and MinimapCluster.IndicatorFrame.CraftingOrderFrame,
+        addonCompartment = AddonCompartmentFrame,
+        difficulty = ResolveFrame(
+            MinimapCluster and MinimapCluster.InstanceDifficulty,
+            MiniMapInstanceDifficulty
+        ),
+        missions = ResolveFrame(
+            ExpansionLandingPageMinimapButton,
+            GarrisonLandingPageMinimapButton
+        ),
+        calendar = GameTimeFrame,
+        tracking = ResolveFrame(
+            MinimapCluster and MinimapCluster.Tracking,
+            MinimapCluster and MinimapCluster.TrackingFrame,
+            MiniMapTracking
+        ),
+    }
+end
+
+-- Apply per-button settings (position, scale, strata, fade)
+local function ApplyButtonSettings(frame, buttonKey, extraOffsetY)
+    if not frame then return end
+
+    local path = "buttons." .. buttonKey
+    local show = module:GetSetting(path .. ".show", false)
+
+    if not show then
+        HideFrame(frame)
+        fadeableButtons[frame] = nil
+        return
+    end
+
+    ShowFrame(frame, buttonHolder)
+
+    local scale   = module:GetSetting(path .. ".scale", 1.0)
+    local strata  = module:GetSetting(path .. ".strata", "MEDIUM")
+    local point   = module:GetSetting(path .. ".point", "CENTER")
+    local offsetX = module:GetSetting(path .. ".offsetX", 0)
+    local offsetY = module:GetSetting(path .. ".offsetY", 0) + (extraOffsetY or 0)
+    local fadeOut = module:GetSetting(path .. ".fadeOut", false)
+
+    frame:SetScale(scale)
+    frame:SetFrameStrata(strata)
+    frame:ClearAllPoints()
+    frame:SetPoint(point, Minimap, point, offsetX, offsetY)
+
+    if fadeOut then
+        SetupFadeHooks()
+        fadeableButtons[frame] = true
+        HookButtonFade(frame)
+        frame:SetAlpha(isMinimapHovered and 1 or 0)
+    else
+        fadeableButtons[frame] = nil
+        frame:SetAlpha(1)
+    end
+end
+
+local function UpdateButtons()
+    local frames = GetButtonFrames()
+
+    -- Zoom: both frames share one config, offset zoomIn above zoomOut
+    local zoomFrames = frames.zoom
+    if zoomFrames then
+        ApplyButtonSettings(zoomFrames[2], "zoom", 0)   -- zoomOut at base
+        ApplyButtonSettings(zoomFrames[1], "zoom", 20)   -- zoomIn 20px above
+    end
+
+    -- All single-frame buttons
+    local singles = {"mail", "craftingOrder", "addonCompartment", "difficulty", "missions", "calendar", "tracking"}
+    for _, key in ipairs(singles) do
+        ApplyButtonSettings(frames[key], key)
+    end
+end
+
+-- Addon Button Hiding (LibDBIcon — separate from per-button system)
+local function UpdateAddonButtons()
+    local hide = module:GetSetting("hideAddonButtons", false)
+    local LDBIcon = LibStub("LibDBIcon-1.0", true)
+    if not LDBIcon then return end
+
+    if hide then
+        pcall(function() LDBIcon:ShowOnEnter(true) end)
+    else
+        pcall(function() LDBIcon:ShowOnEnter(false) end)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Dungeon Eye (QueueStatusButton)
+--------------------------------------------------------------------------------
+
+local function UpdateDungeonEye()
+    local btn = QueueStatusButton
+    if not btn then return end
+
+    local enabled = module:GetSetting("dungeonEye.enabled", true)
+    if not enabled then
+        HideFrame(btn)
+        return
+    end
+
+    ShowFrame(btn, buttonHolder)
+
+    local corner = module:GetSetting("dungeonEye.corner", "BOTTOMRIGHT")
+    local scale = module:GetSetting("dungeonEye.scale", 0.8)
+    local offsetX = module:GetSetting("dungeonEye.offsetX", 0)
+    local offsetY = module:GetSetting("dungeonEye.offsetY", 0)
+
+    btn:SetScale(scale)
+    btn:ClearAllPoints()
+    btn:SetPoint(corner, Minimap, corner, offsetX, offsetY)
+
+    -- Hook UpdatePosition to persist our placement
+    if not btn._tavernHooked then
+        btn._tavernHooked = true
+        hooksecurefunc(btn, "UpdatePosition", function()
+            if module:IsEnabled() and module:GetSetting("dungeonEye.enabled", true) then
+                local c = module:GetSetting("dungeonEye.corner", "BOTTOMRIGHT")
+                local s = module:GetSetting("dungeonEye.scale", 0.8)
+                local ox = module:GetSetting("dungeonEye.offsetX", 0)
+                local oy = module:GetSetting("dungeonEye.offsetY", 0)
+                btn:SetScale(s)
+                btn:ClearAllPoints()
+                btn:SetPoint(c, Minimap, c, ox, oy)
+            end
+        end)
+    end
+end
+
+--------------------------------------------------------------------------------
+-- Pet Battles
+--------------------------------------------------------------------------------
+
+local petBattleFrame = CreateFrame("Frame")
+petBattleFrame:RegisterEvent("PET_BATTLE_OPENING_START")
+petBattleFrame:RegisterEvent("PET_BATTLE_CLOSE")
+petBattleFrame:SetScript("OnEvent", function(_, event)
+    local mod = TavernUI:GetModule("Minimap", true)
+    if not mod or not mod:IsEnabled() then return end
+
+    if event == "PET_BATTLE_OPENING_START" then
+        Minimap:Hide()
+        if mod.backdropFrame then
+            mod.backdropFrame:Hide()
+        end
+    elseif event == "PET_BATTLE_CLOSE" then
+        Minimap:Show()
+        if mod.backdropFrame then
+            mod.backdropFrame:Show()
+        end
+    end
+end)
+
+--------------------------------------------------------------------------------
+-- Calendar Invites
+--------------------------------------------------------------------------------
+
+local calendarFrame = CreateFrame("Frame")
+calendarFrame:RegisterEvent("CALENDAR_UPDATE_PENDING_INVITES")
+calendarFrame:RegisterEvent("PLAYER_ENTERING_WORLD")
+calendarFrame:SetScript("OnEvent", function()
+    local mod = TavernUI:GetModule("Minimap", true)
+    if not mod or not mod:IsEnabled() then return end
+
+    if GameTimeFrame and not mod:GetSetting("buttons.calendar.show", false) then
+        local numPending = C_Calendar.GetNumPendingInvites()
+        if numPending and numPending > 0 then
+            GameTimeFrame:Show()
+        else
+            GameTimeFrame:Hide()
+        end
+    end
+end)
+
+--------------------------------------------------------------------------------
+-- Zone Change Events
+--------------------------------------------------------------------------------
+
+local zoneEventFrame = CreateFrame("Frame")
+zoneEventFrame:RegisterEvent("ZONE_CHANGED")
+zoneEventFrame:RegisterEvent("ZONE_CHANGED_INDOORS")
+zoneEventFrame:RegisterEvent("ZONE_CHANGED_NEW_AREA")
+zoneEventFrame:SetScript("OnEvent", function()
+    local mod = TavernUI:GetModule("Minimap", true)
+    if not mod or not mod:IsEnabled() then return end
+    UpdateZoneText()
+end)
+
+--------------------------------------------------------------------------------
+-- Public API
+--------------------------------------------------------------------------------
+
+function Elements.Setup()
+    CreateZoneText()
+    CreateCoords()
+    CreateClock()
+
+    -- Hide Blizzard zone text
+    if MinimapCluster and MinimapCluster.ZoneTextButton then
+        MinimapCluster.ZoneTextButton:Hide()
+    end
+    if MinimapZoneText then
+        MinimapZoneText:Hide()
+    end
+    if MinimapZoneTextButton then
+        MinimapZoneTextButton:Hide()
+    end
+
+    Elements.RefreshAll()
+end
+
+function Elements.RefreshAll()
+    UpdateZoneText()
+    UpdateCoords()
+    UpdateClock()
+    UpdateButtons()
+    UpdateAddonButtons()
+    UpdateDungeonEye()
+end
+
+local function StartCoordsTicker()
+    local interval = module:GetSetting("coords.updateInterval", 1)
+    interval = math.max(interval, 0.1)  -- minimum 100ms to prevent spam
+    coordsTicker = C_Timer.NewTicker(interval, function()
+        if module:IsEnabled() then
+            UpdateCoords()
+        end
+    end)
+end
+
+function Elements.StartTickers()
+    Elements.StopTickers()
+
+    -- Clock ticker (1 second)
+    clockTicker = C_Timer.NewTicker(1, function()
+        if module:IsEnabled() then
+            UpdateClock()
+        end
+    end)
+
+    -- Coords ticker (configurable interval)
+    StartCoordsTicker()
+end
+
+function Elements.RefreshCoordsTicker()
+    if coordsTicker then
+        coordsTicker:Cancel()
+        coordsTicker = nil
+    end
+    if not module:IsEnabled() then
+        return
+    end
+    StartCoordsTicker()
+end
+
+function Elements.StopTickers()
+    if clockTicker then
+        clockTicker:Cancel()
+        clockTicker = nil
+    end
+    if coordsTicker then
+        coordsTicker:Cancel()
+        coordsTicker = nil
+    end
+end
+
+-- Expose individual updaters for options panel instant feedback
+Elements.UpdateZoneText = UpdateZoneText
+Elements.UpdateCoords = UpdateCoords
+Elements.UpdateClock = UpdateClock
+Elements.UpdateButtons = UpdateButtons
+Elements.UpdateAddonButtons = UpdateAddonButtons
+Elements.UpdateDungeonEye = UpdateDungeonEye

--- a/Modules/Minimap/Minimap_Options.lua
+++ b/Modules/Minimap/Minimap_Options.lua
@@ -1,0 +1,1117 @@
+local TavernUI = LibStub("AceAddon-3.0"):GetAddon("TavernUI")
+local module = TavernUI:GetModule("Minimap", true)
+
+if not module then return end
+
+local ANCHOR_POSITIONS = {
+    TOPLEFT = "Top Left",
+    TOP = "Top",
+    TOPRIGHT = "Top Right",
+    LEFT = "Left",
+    CENTER = "Center",
+    RIGHT = "Right",
+    BOTTOMLEFT = "Bottom Left",
+    BOTTOM = "Bottom",
+    BOTTOMRIGHT = "Bottom Right",
+}
+
+local function GetFontValues()
+    return TavernUI:GetLSMMediaDropdownValues("font", "", "Default")
+end
+
+local STRATA_VALUES = {
+    BACKGROUND = "Background",
+    LOW = "Low",
+    MEDIUM = "Medium",
+    HIGH = "High",
+    DIALOG = "Dialog",
+}
+
+--------------------------------------------------------------------------------
+-- Tab 1: General
+--------------------------------------------------------------------------------
+
+local function BuildGeneralTab()
+    local args = {}
+    local order = 1
+
+    args.shapeHeader = {type = "header", name = "Shape & Size", order = order}
+    order = order + 1
+
+    args.shape = {
+        type = "select",
+        name = "Shape",
+        desc = "Minimap shape",
+        order = order,
+        values = {SQUARE = "Square", ROUND = "Round"},
+        get = function() return module:GetSetting("shape", "SQUARE") end,
+        set = function(_, value)
+            module:SetSetting("shape", value)
+            module:SetShape()
+            if module.Elements then module.Elements.RefreshAll() end
+        end,
+    }
+    order = order + 1
+
+    args.size = {
+        type = "range",
+        name = "Size",
+        desc = "Minimap size in pixels",
+        order = order,
+        min = 120, max = 380, step = 1,
+        get = function() return module:GetSetting("size", 180) end,
+        set = function(_, value)
+            module:SetSetting("size", value, {type = "number", min = 120, max = 380})
+            module:UpdateSize()
+            module:UpdateBackdrop()
+            if module.Elements then module.Elements.RefreshAll() end
+        end,
+    }
+    order = order + 1
+
+    args.lock = {
+        type = "toggle",
+        name = "Lock Position",
+        desc = "Prevent minimap from being dragged",
+        order = order,
+        get = function() return module:GetSetting("lock", false) end,
+        set = function(_, value)
+            module:SetSetting("lock", value)
+            module:UpdateLock()
+        end,
+    }
+    order = order + 1
+
+    args.borderHeader = {type = "header", name = "Border", order = order}
+    order = order + 1
+
+    args.borderSize = {
+        type = "range",
+        name = "Border Size",
+        desc = "Border thickness in pixels (0 = no border)",
+        order = order,
+        min = 0, max = 10, step = 1,
+        get = function() return module:GetSetting("borderSize", 3) end,
+        set = function(_, value)
+            module:SetSetting("borderSize", value, {type = "number", min = 0, max = 10})
+            module:UpdateBackdrop()
+        end,
+    }
+    order = order + 1
+
+    args.borderColor = {
+        type = "color",
+        name = "Border Color",
+        desc = "Color of the minimap border",
+        order = order,
+        hasAlpha = true,
+        disabled = function()
+            return module:GetSetting("borderSize", 3) == 0 or module:GetSetting("useClassColorBorder", false)
+        end,
+        get = function()
+            local c = module:GetSetting("borderColor", {r=0, g=0, b=0, a=1})
+            return c.r or 0, c.g or 0, c.b or 0, c.a or 1
+        end,
+        set = function(_, r, g, b, a)
+            module:SetSetting("borderColor", {r=r, g=g, b=b, a=a})
+            module:UpdateBackdrop()
+        end,
+    }
+    order = order + 1
+
+    args.useClassColorBorder = {
+        type = "toggle",
+        name = "Class Color Border",
+        desc = "Use your class color for the border",
+        order = order,
+        disabled = function() return module:GetSetting("borderSize", 3) == 0 end,
+        get = function() return module:GetSetting("useClassColorBorder", false) end,
+        set = function(_, value)
+            module:SetSetting("useClassColorBorder", value)
+            module:UpdateBackdrop()
+        end,
+    }
+    order = order + 1
+
+    args.zoomHeader = {type = "header", name = "Zoom", order = order}
+    order = order + 1
+
+    args.mouseWheelZoom = {
+        type = "toggle",
+        name = "Mouse Wheel Zoom",
+        desc = "Enable zooming with the mouse wheel",
+        order = order,
+        get = function() return module:GetSetting("mouseWheelZoom", true) end,
+        set = function(_, value)
+            module:SetSetting("mouseWheelZoom", value)
+            module:SetupMouseWheelZoom()
+        end,
+    }
+    order = order + 1
+
+    args.autoZoomOut = {
+        type = "toggle",
+        name = "Auto Zoom Out",
+        desc = "Automatically zoom out after 15 seconds",
+        order = order,
+        get = function() return module:GetSetting("autoZoomOut", true) end,
+        set = function(_, value)
+            module:SetSetting("autoZoomOut", value)
+            module:SetupAutoZoom()
+        end,
+    }
+    order = order + 1
+
+    args.displayHeader = {type = "header", name = "Display", order = order}
+    order = order + 1
+
+    args.strata = {
+        type = "select",
+        name = "Frame Strata",
+        desc = "Rendering layer for the minimap",
+        order = order,
+        values = STRATA_VALUES,
+        get = function() return module:GetSetting("strata", "BACKGROUND") end,
+        set = function(_, value)
+            module:SetSetting("strata", value)
+            module:UpdateStrata()
+        end,
+    }
+    order = order + 1
+
+    args.lineBreak1 = {
+        type = "description", name = " ", order = order, width = "full",
+        disabled = true
+    }
+    order = order + 1
+
+    args.opacity = {
+        type = "range",
+        name = "Opacity",
+        desc = "Base minimap opacity",
+        order = order,
+        min = 0.1, max = 1.0, step = 0.05, isPercent = true,
+        get = function() return module:GetSetting("opacity", 1.0) end,
+        set = function(_, value)
+            module:SetSetting("opacity", value, {type = "number", min = 0.1, max = 1.0})
+            module:ApplyOpacity()
+        end,
+    }
+    order = order + 1
+
+    args.opacityMoving = {
+        type = "range",
+        name = "Opacity When Moving",
+        desc = "Minimap opacity while the player is moving",
+        order = order,
+        min = 0.0, max = 1.0, step = 0.05, isPercent = true,
+        get = function() return module:GetSetting("opacityMoving", 1.0) end,
+        set = function(_, value)
+            module:SetSetting("opacityMoving", value, {type = "number", min = 0.0, max = 1.0})
+            module:ApplyOpacity()
+        end,
+    }
+    order = order + 1
+
+    args.opacityMounted = {
+        type = "range",
+        name = "Opacity When Mounted",
+        desc = "Minimap opacity while mounted (overrides moving opacity)",
+        order = order,
+        min = 0.0, max = 1.0, step = 0.05, isPercent = true,
+        get = function() return module:GetSetting("opacityMounted", 1.0) end,
+        set = function(_, value)
+            module:SetSetting("opacityMounted", value, {type = "number", min = 0.0, max = 1.0})
+            module:ApplyOpacity()
+        end,
+    }
+    order = order + 1
+
+    return args
+end
+
+--------------------------------------------------------------------------------
+-- Tab 2: Elements
+--------------------------------------------------------------------------------
+
+local function BuildElementsTab()
+    local args = {}
+    local order = 1
+
+    -- Zone Text subgroup
+    args.zoneTextGroup = {
+        type = "group",
+        name = "Zone Text",
+        order = order,
+        inline = true,
+        args = {},
+    }
+    order = order + 1
+
+    local zo = 1
+    args.zoneTextGroup.args.showZoneText = {
+        type = "toggle",
+        name = "Show Zone Text",
+        desc = "Display the zone name on the minimap",
+        order = zo, width = "full",
+        get = function() return module:GetSetting("showZoneText", true) end,
+        set = function(_, value)
+            module:SetSetting("showZoneText", value)
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.position = {
+        type = "select",
+        name = "Position",
+        desc = "Anchor position on the minimap",
+        order = zo,
+        values = ANCHOR_POSITIONS,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.position", "TOP") end,
+        set = function(_, value)
+            module:SetSetting("zoneText.position", value)
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.offsetX = {
+        type = "range",
+        name = "Offset X",
+        order = zo, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.offsetX", 0) end,
+        set = function(_, value)
+            module:SetSetting("zoneText.offsetX", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.offsetY = {
+        type = "range",
+        name = "Offset Y",
+        order = zo, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.offsetY", -2) end,
+        set = function(_, value)
+            module:SetSetting("zoneText.offsetY", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.lineBreak1 = {
+        type = "description", name = " ", order = zo, width = "full",
+        disabled = true
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.font = {
+        type = "select",
+
+        name = "Font",
+        desc = "Font face for zone text",
+        order = zo,
+        values = GetFontValues,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.font", "") end,
+        set = function(_, value)
+            module:SetSetting("zoneText.font", value)
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.fontSize = {
+        type = "range",
+        name = "Font Size",
+        order = zo, min = 8, max = 24, step = 1,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.fontSize", 12) end,
+        set = function(_, value)
+            module:SetSetting("zoneText.fontSize", value, {type = "number", min = 8, max = 24})
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.allCaps = {
+        type = "toggle",
+        name = "All Caps",
+        desc = "Display zone text in uppercase",
+        order = zo,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.allCaps", true) end,
+        set = function(_, value)
+            module:SetSetting("zoneText.allCaps", value)
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.lineBreak2 = {
+        type = "description", name = " ", order = zo, width = "full",
+        disabled = true
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.fadeOut = {
+        type = "toggle",
+        name = "Fade When Not Hovering",
+        desc = "Hide zone text when the mouse is not over the minimap",
+        order = zo,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.fadeOut", false) end,
+        set = function(_, value)
+            module:SetSetting("zoneText.fadeOut", value)
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.lineBreak3 = {
+        type = "description", name = " ", order = zo, width = "full",
+        disabled = true
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.useClassColor = {
+        type = "toggle",
+        name = "Use Class Color",
+        desc = "Override PvP zone colors with your class color",
+        order = zo,
+        disabled = function() return not module:GetSetting("showZoneText", true) end,
+        get = function() return module:GetSetting("zoneText.useClassColor", false) end,
+        set = function(_, value)
+            module:SetSetting("zoneText.useClassColor", value)
+            if module.Elements then module.Elements.UpdateZoneText() end
+        end,
+    }
+    zo = zo + 1
+
+    args.zoneTextGroup.args.lineBreak4 = {
+        type = "description", name = " ", order = zo, width = "full",
+        disabled = true
+    }
+    zo = zo + 1
+
+    local zoneColors = {
+        {key = "colorSanctuary", name = "Sanctuary", default = {r=0.41, g=0.80, b=0.94, a=1}},
+        {key = "colorArena",     name = "Arena/Combat", default = {r=1.00, g=0.10, b=0.10, a=1}},
+        {key = "colorFriendly",  name = "Friendly", default = {r=0.10, g=1.00, b=0.10, a=1}},
+        {key = "colorHostile",   name = "Hostile", default = {r=1.00, g=0.10, b=0.10, a=1}},
+        {key = "colorContested", name = "Contested", default = {r=1.00, g=0.70, b=0.00, a=1}},
+        {key = "colorNormal",    name = "Normal", default = {r=1.00, g=0.82, b=0.00, a=1}},
+    }
+
+    for _, zc in ipairs(zoneColors) do
+        args.zoneTextGroup.args[zc.key] = {
+            type = "color",
+            name = zc.name,
+            order = zo,
+            hasAlpha = false,
+            disabled = function()
+                return not module:GetSetting("showZoneText", true)
+                    or module:GetSetting("zoneText.useClassColor", false)
+            end,
+            get = function()
+                local c = module:GetSetting("zoneText." .. zc.key, zc.default)
+                return c.r or 1, c.g or 1, c.b or 1
+            end,
+            set = function(_, r, g, b)
+                module:SetSetting("zoneText." .. zc.key, {r=r, g=g, b=b, a=1})
+                if module.Elements then module.Elements.UpdateZoneText() end
+            end,
+        }
+        zo = zo + 1
+    end
+
+    -- Coordinates subgroup
+    args.coordsGroup = {
+        type = "group",
+        name = "Coordinates",
+        order = order,
+        inline = true,
+        args = {},
+    }
+    order = order + 1
+
+    local co = 1
+    args.coordsGroup.args.showCoords = {
+        type = "toggle",
+        name = "Show Coordinates",
+        desc = "Display player coordinates on the minimap",
+        order = co, width = "full",
+        get = function() return module:GetSetting("showCoords", true) end,
+        set = function(_, value)
+            module:SetSetting("showCoords", value)
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.position = {
+        type = "select",
+        name = "Position",
+        desc = "Anchor position on the minimap",
+        order = co,
+        values = ANCHOR_POSITIONS,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.position", "TOPRIGHT") end,
+        set = function(_, value)
+            module:SetSetting("coords.position", value)
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.offsetX = {
+        type = "range",
+        name = "Offset X",
+        order = co, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.offsetX", -2) end,
+        set = function(_, value)
+            module:SetSetting("coords.offsetX", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.offsetY = {
+        type = "range",
+        name = "Offset Y",
+        order = co, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.offsetY", -2) end,
+        set = function(_, value)
+            module:SetSetting("coords.offsetY", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.lineBreak1 = {
+        type = "description", name = " ", order = co, width = "full",
+        disabled = true
+    }
+    co = co + 1
+
+    args.coordsGroup.args.font = {
+        type = "select",
+
+        name = "Font",
+        desc = "Font face for coordinates",
+        order = co,
+        values = GetFontValues,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.font", "") end,
+        set = function(_, value)
+            module:SetSetting("coords.font", value)
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.fontSize = {
+        type = "range",
+        name = "Font Size",
+        order = co, min = 8, max = 24, step = 1,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.fontSize", 12) end,
+        set = function(_, value)
+            module:SetSetting("coords.fontSize", value, {type = "number", min = 8, max = 24})
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.precision = {
+        type = "select",
+        name = "Precision",
+        desc = "Decimal precision for coordinates",
+        order = co,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        values = {
+            ["%.0f, %.0f"] = "No decimals",
+            ["%.1f, %.1f"] = "1 decimal",
+            ["%.2f, %.2f"] = "2 decimals",
+        },
+        get = function() return module:GetSetting("coords.precision", "%.1f, %.1f") end,
+        set = function(_, value)
+            module:SetSetting("coords.precision", value)
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.lineBreak2 = {
+        type = "description", name = " ", order = co, width = "full",
+        disabled = true
+    }
+    co = co + 1
+
+    args.coordsGroup.args.updateInterval = {
+        type = "range",
+        name = "Update Interval",
+        desc = "How often coordinates update (in seconds)",
+        order = co, min = 0.1, max = 5, step = 0.1,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.updateInterval", 1) end,
+        set = function(_, value)
+            module:SetSetting("coords.updateInterval", value, {type = "number", min = 0.1, max = 5})
+            module:RestartTickers()
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.lineBreak3 = {
+        type = "description", name = " ", order = co, width = "full",
+        disabled = true
+    }
+    co = co + 1
+
+    args.coordsGroup.args.fadeOut = {
+        type = "toggle",
+        name = "Fade When Not Hovering",
+        desc = "Hide coordinates when the mouse is not over the minimap",
+        order = co,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.fadeOut", false) end,
+        set = function(_, value)
+            module:SetSetting("coords.fadeOut", value)
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.lineBreak4 = {
+        type = "description", name = " ", order = co, width = "full",
+        disabled = true
+    }
+    co = co + 1
+
+    args.coordsGroup.args.useClassColor = {
+        type = "toggle",
+        name = "Use Class Color",
+        order = co,
+        disabled = function() return not module:GetSetting("showCoords", true) end,
+        get = function() return module:GetSetting("coords.useClassColor", false) end,
+        set = function(_, value)
+            module:SetSetting("coords.useClassColor", value)
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    args.coordsGroup.args.lineBreak5 = {
+        type = "description", name = " ", order = co, width = "full",
+        disabled = true
+    }
+    co = co + 1
+
+    args.coordsGroup.args.color = {
+        type = "color",
+        name = "Text Color",
+        order = co,
+        hasAlpha = true,
+        disabled = function()
+            return not module:GetSetting("showCoords", true)
+                or module:GetSetting("coords.useClassColor", false)
+        end,
+        get = function()
+            local c = module:GetSetting("coords.color", {r=1, g=1, b=1, a=1})
+            return c.r or 1, c.g or 1, c.b or 1, c.a or 1
+        end,
+        set = function(_, r, g, b, a)
+            module:SetSetting("coords.color", {r=r, g=g, b=b, a=a})
+            if module.Elements then module.Elements.UpdateCoords() end
+        end,
+    }
+    co = co + 1
+
+    -- Clock subgroup
+    args.clockGroup = {
+        type = "group",
+        name = "Clock",
+        order = order,
+        inline = true,
+        args = {},
+    }
+    order = order + 1
+
+    local clo = 1
+    args.clockGroup.args.showClock = {
+        type = "toggle",
+        name = "Show Clock",
+        desc = "Display a clock on the minimap",
+        order = clo, width = "full",
+        get = function() return module:GetSetting("showClock", true) end,
+        set = function(_, value)
+            module:SetSetting("showClock", value)
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.position = {
+        type = "select",
+        name = "Position",
+        desc = "Anchor position on the minimap",
+        order = clo,
+        values = ANCHOR_POSITIONS,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.position", "TOPLEFT") end,
+        set = function(_, value)
+            module:SetSetting("clock.position", value)
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.offsetX = {
+        type = "range",
+        name = "Offset X",
+        order = clo, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.offsetX", 2) end,
+        set = function(_, value)
+            module:SetSetting("clock.offsetX", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.offsetY = {
+        type = "range",
+        name = "Offset Y",
+        order = clo, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.offsetY", -2) end,
+        set = function(_, value)
+            module:SetSetting("clock.offsetY", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.lineBreak1 = {
+        type = "description", name = " ", order = clo, width = "full",
+        disabled = true
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.font = {
+        type = "select",
+
+        name = "Font",
+        desc = "Font face for the clock",
+        order = clo,
+        values = GetFontValues,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.font", "") end,
+        set = function(_, value)
+            module:SetSetting("clock.font", value)
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.fontSize = {
+        type = "range",
+        name = "Font Size",
+        order = clo, min = 8, max = 24, step = 1,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.fontSize", 12) end,
+        set = function(_, value)
+            module:SetSetting("clock.fontSize", value, {type = "number", min = 8, max = 24})
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.lineBreak2 = {
+        type = "description", name = " ", order = clo, width = "full",
+        disabled = true
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.timeSource = {
+        type = "select",
+        name = "Time Source",
+        desc = "Use local system time or server time",
+        order = clo,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        values = {["local"] = "Local Time", server = "Server Time"},
+        get = function() return module:GetSetting("clock.timeSource", "local") end,
+        set = function(_, value)
+            module:SetSetting("clock.timeSource", value)
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.use24Hour = {
+        type = "toggle",
+        name = "24-Hour Format",
+        desc = "Use 24-hour time format",
+        order = clo,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.use24Hour", true) end,
+        set = function(_, value)
+            module:SetSetting("clock.use24Hour", value)
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.lineBreak3 = {
+        type = "description", name = " ", order = clo, width = "full",
+        disabled = true
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.fadeOut = {
+        type = "toggle",
+        name = "Fade When Not Hovering",
+        desc = "Hide clock when the mouse is not over the minimap",
+        order = clo,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.fadeOut", false) end,
+        set = function(_, value)
+            module:SetSetting("clock.fadeOut", value)
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.lineBreak4 = {
+        type = "description", name = " ", order = clo, width = "full",
+        disabled = true
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.useClassColor = {
+        type = "toggle",
+        name = "Use Class Color",
+        order = clo,
+        disabled = function() return not module:GetSetting("showClock", true) end,
+        get = function() return module:GetSetting("clock.useClassColor", false) end,
+        set = function(_, value)
+            module:SetSetting("clock.useClassColor", value)
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.lineBreak5 = {
+        type = "description", name = " ", order = clo, width = "full",
+        disabled = true
+    }
+    clo = clo + 1
+
+    args.clockGroup.args.color = {
+        type = "color",
+        name = "Text Color",
+        order = clo,
+        hasAlpha = true,
+        disabled = function()
+            return not module:GetSetting("showClock", true)
+                or module:GetSetting("clock.useClassColor", false)
+        end,
+        get = function()
+            local c = module:GetSetting("clock.color", {r=1, g=1, b=1, a=1})
+            return c.r or 1, c.g or 1, c.b or 1, c.a or 1
+        end,
+        set = function(_, r, g, b, a)
+            module:SetSetting("clock.color", {r=r, g=g, b=b, a=a})
+            if module.Elements then module.Elements.UpdateClock() end
+        end,
+    }
+    clo = clo + 1
+
+    return args
+end
+
+--------------------------------------------------------------------------------
+-- Tab 3: Buttons
+--------------------------------------------------------------------------------
+
+local BUTTON_DEFS = {
+    {key = "zoom",             name = "Zoom Buttons",       defaultShow = false, defaultPoint = "BOTTOMRIGHT"},
+    {key = "mail",             name = "Mail Indicator",      defaultShow = true,  defaultPoint = "BOTTOMLEFT"},
+    {key = "craftingOrder",    name = "Crafting Orders",     defaultShow = true,  defaultPoint = "BOTTOMRIGHT"},
+    {key = "addonCompartment", name = "Addon Compartment",   defaultShow = false, defaultPoint = "TOPRIGHT"},
+    {key = "difficulty",       name = "Instance Difficulty",  defaultShow = true,  defaultPoint = "TOPLEFT"},
+    {key = "missions",         name = "Missions Button",     defaultShow = false, defaultPoint = "TOPLEFT"},
+    {key = "calendar",         name = "Calendar",            defaultShow = false, defaultPoint = "TOPRIGHT"},
+    {key = "tracking",         name = "Tracking Button",     defaultShow = true,  defaultPoint = "TOPLEFT"},
+}
+
+local function BuildButtonsTab()
+    local args = {}
+    local order = 1
+
+    args.buttonsHeader = {type = "header", name = "Built-in Buttons", order = order}
+    order = order + 1
+
+    for _, btn in ipairs(BUTTON_DEFS) do
+        local path = "buttons." .. btn.key
+        local subArgs = {}
+        local so = 1
+
+        subArgs.show = {
+            type = "toggle",
+            name = "Show",
+            desc = "Show or hide this button",
+            order = so, width = "full",
+            get = function() return module:GetSetting(path .. ".show", btn.defaultShow) end,
+            set = function(_, value)
+                module:SetSetting(path .. ".show", value)
+                if module.Elements then module.Elements.UpdateButtons() end
+            end,
+        }
+        so = so + 1
+
+        subArgs.scale = {
+            type = "range",
+            name = "Scale",
+            desc = "Button size multiplier",
+            order = so, min = 0.3, max = 3.0, step = 0.05,
+            disabled = function() return not module:GetSetting(path .. ".show", btn.defaultShow) end,
+            get = function() return module:GetSetting(path .. ".scale", 1.0) end,
+            set = function(_, value)
+                module:SetSetting(path .. ".scale", value, {type = "number", min = 0.3, max = 3.0})
+                if module.Elements then module.Elements.UpdateButtons() end
+            end,
+        }
+        so = so + 1
+
+        subArgs.strata = {
+            type = "select",
+            name = "Frame Strata",
+            desc = "Rendering layer for this button",
+            order = so,
+            values = STRATA_VALUES,
+            disabled = function() return not module:GetSetting(path .. ".show", btn.defaultShow) end,
+            get = function() return module:GetSetting(path .. ".strata", "MEDIUM") end,
+            set = function(_, value)
+                module:SetSetting(path .. ".strata", value)
+                if module.Elements then module.Elements.UpdateButtons() end
+            end,
+        }
+        so = so + 1
+
+        subArgs.point = {
+            type = "select",
+            name = "Anchor Point",
+            desc = "Where to anchor this button on the minimap",
+            order = so,
+            values = ANCHOR_POSITIONS,
+            disabled = function() return not module:GetSetting(path .. ".show", btn.defaultShow) end,
+            get = function() return module:GetSetting(path .. ".point", btn.defaultPoint) end,
+            set = function(_, value)
+                module:SetSetting(path .. ".point", value)
+                if module.Elements then module.Elements.UpdateButtons() end
+            end,
+        }
+        so = so + 1
+
+        subArgs.offsetX = {
+            type = "range",
+            name = "Offset X",
+            order = so, min = -200, max = 200, step = 1,
+            disabled = function() return not module:GetSetting(path .. ".show", btn.defaultShow) end,
+            get = function() return module:GetSetting(path .. ".offsetX", 0) end,
+            set = function(_, value)
+                module:SetSetting(path .. ".offsetX", value, {type = "number", min = -200, max = 200})
+                if module.Elements then module.Elements.UpdateButtons() end
+            end,
+        }
+        so = so + 1
+
+        subArgs.offsetY = {
+            type = "range",
+            name = "Offset Y",
+            order = so, min = -200, max = 200, step = 1,
+            disabled = function() return not module:GetSetting(path .. ".show", btn.defaultShow) end,
+            get = function() return module:GetSetting(path .. ".offsetY", 0) end,
+            set = function(_, value)
+                module:SetSetting(path .. ".offsetY", value, {type = "number", min = -200, max = 200})
+                if module.Elements then module.Elements.UpdateButtons() end
+            end,
+        }
+        so = so + 1
+
+        subArgs.fadeOut = {
+            type = "toggle",
+            name = "Fade When Not Hovering",
+            desc = "Hide this button when the mouse is not over the minimap",
+            order = so,
+            disabled = function() return not module:GetSetting(path .. ".show", btn.defaultShow) end,
+            get = function() return module:GetSetting(path .. ".fadeOut", false) end,
+            set = function(_, value)
+                module:SetSetting(path .. ".fadeOut", value)
+                if module.Elements then module.Elements.UpdateButtons() end
+            end,
+        }
+        so = so + 1
+
+        args[btn.key] = {
+            type = "group",
+            name = btn.name,
+            order = order,
+            inline = true,
+            args = subArgs,
+        }
+        order = order + 1
+    end
+
+    args.addonHeader = {type = "header", name = "Addon Buttons", order = order}
+    order = order + 1
+
+    args.hideAddonButtons = {
+        type = "toggle",
+        name = "Hide Addon Buttons",
+        desc = "Show LibDBIcon buttons only on minimap hover",
+        order = order,
+        get = function() return module:GetSetting("hideAddonButtons", false) end,
+        set = function(_, value)
+            module:SetSetting("hideAddonButtons", value)
+            if module.Elements then module.Elements.UpdateAddonButtons() end
+        end,
+    }
+    order = order + 1
+
+    args.dungeonEyeHeader = {type = "header", name = "Dungeon Eye", order = order}
+    order = order + 1
+
+    args.dungeonEyeEnabled = {
+        type = "toggle",
+        name = "Enable Dungeon Eye",
+        desc = "Show the queue status button near the minimap",
+        order = order,
+        get = function() return module:GetSetting("dungeonEye.enabled", true) end,
+        set = function(_, value)
+            module:SetSetting("dungeonEye.enabled", value)
+            if module.Elements then module.Elements.UpdateDungeonEye() end
+        end,
+    }
+    order = order + 1
+
+    args.dungeonEyeCorner = {
+        type = "select",
+        name = "Anchor Point",
+        desc = "Where to anchor the dungeon eye on the minimap",
+        order = order,
+        values = ANCHOR_POSITIONS,
+        disabled = function() return not module:GetSetting("dungeonEye.enabled", true) end,
+        get = function() return module:GetSetting("dungeonEye.corner", "BOTTOMRIGHT") end,
+        set = function(_, value)
+            module:SetSetting("dungeonEye.corner", value)
+            if module.Elements then module.Elements.UpdateDungeonEye() end
+        end,
+    }
+    order = order + 1
+
+    args.dungeonEyeScale = {
+        type = "range",
+        name = "Scale",
+        order = order, min = 0.3, max = 2.0, step = 0.05,
+        disabled = function() return not module:GetSetting("dungeonEye.enabled", true) end,
+        get = function() return module:GetSetting("dungeonEye.scale", 0.8) end,
+        set = function(_, value)
+            module:SetSetting("dungeonEye.scale", value, {type = "number", min = 0.3, max = 2.0})
+            if module.Elements then module.Elements.UpdateDungeonEye() end
+        end,
+    }
+    order = order + 1
+
+    args.dungeonEyeOffsetX = {
+        type = "range",
+        name = "Offset X",
+        order = order, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("dungeonEye.enabled", true) end,
+        get = function() return module:GetSetting("dungeonEye.offsetX", 0) end,
+        set = function(_, value)
+            module:SetSetting("dungeonEye.offsetX", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateDungeonEye() end
+        end,
+    }
+    order = order + 1
+
+    args.dungeonEyeOffsetY = {
+        type = "range",
+        name = "Offset Y",
+        order = order, min = -100, max = 100, step = 1,
+        disabled = function() return not module:GetSetting("dungeonEye.enabled", true) end,
+        get = function() return module:GetSetting("dungeonEye.offsetY", 0) end,
+        set = function(_, value)
+            module:SetSetting("dungeonEye.offsetY", value, {type = "number", min = -100, max = 100})
+            if module.Elements then module.Elements.UpdateDungeonEye() end
+        end,
+    }
+    order = order + 1
+
+    return args
+end
+
+--------------------------------------------------------------------------------
+-- Build & Register
+--------------------------------------------------------------------------------
+
+function module:BuildOptions()
+    if not TavernUI.db or not TavernUI.db.profile then
+        return
+    end
+
+    local options = {
+        type = "group",
+        name = "Minimap",
+        childGroups = "tab",
+        args = {
+            general = {
+                type = "group",
+                name = "General",
+                order = 1,
+                args = BuildGeneralTab(),
+            },
+            elements = {
+                type = "group",
+                name = "Elements",
+                order = 2,
+                args = BuildElementsTab(),
+            },
+            buttons = {
+                type = "group",
+                name = "Buttons",
+                order = 3,
+                args = BuildButtonsTab(),
+            },
+        },
+    }
+
+    TavernUI:RegisterModuleOptions("Minimap", options, "Minimap")
+end
+
+function module:RegisterOptions()
+    if not self.optionsBuilt then
+        self:BuildOptions()
+        self.optionsBuilt = true
+    end
+end
+
+local function BuildOptionsWhenReady()
+    if TavernUI and TavernUI.db and TavernUI.db.profile and TavernUI.RegisterModuleOptions then
+        module:RegisterOptions()
+    end
+end
+
+module:RegisterMessage("TavernUI_CoreEnabled", BuildOptionsWhenReady)
+
+if TavernUI and TavernUI.db and TavernUI.RegisterModuleOptions then
+    BuildOptionsWhenReady()
+end

--- a/Modules/Modules.xml
+++ b/Modules/Modules.xml
@@ -5,4 +5,5 @@
 	<Include file="ResourceBars\ResourceBars.xml"/>
 	<Include file="Skins\Skins.xml"/>
 	<Script file="QoL\QoL.lua"/>
+	<Include file="Minimap\Minimap.xml"/>
 </Ui>


### PR DESCRIPTION
## Summary

Add a new Minimap module that replaces Blizzard's default minimap chrome with a fully configurable alternative.

### Core Features
- **Shape**: Square or round, with proper mask handling for both the minimap and HybridMinimap (Dragonflight world map overlay)
- **Size & Scale**: Adjustable minimap size (120-380px) and cluster scale (0.5-2.0x)
- **Draggable positioning**: Freely move the minimap anywhere on screen, with optional lock
- **Border**: Configurable thickness, color, and class-color option; shape-aware rendering (solid edge for square, masked circle texture for round)
- **Frame strata**: Configurable rendering layer (Background through Dialog)
- **Dynamic opacity**: Base opacity plus separate overrides for moving and mounted states, driven by `PLAYER_STARTED_MOVING`, `PLAYER_STOPPED_MOVING`, and `PLAYER_MOUNT_DISPLAY_CHANGED` events

### Text Elements (Zone Text, Coordinates, Clock)
- Per-element toggle, anchor position, offset, font size, and fade-on-hover
- Font selection via LibSharedMedia with `SafeSetFont` fallback (gracefully recovers if a font path is invalid, preventing FontString corruption)
- Zone text: PvP-aware coloring (sanctuary, friendly, hostile, contested, arena) with class-color override, all-caps option
- Coordinates: configurable precision and update interval
- Clock: local or server time, 12/24-hour format, left-click opens calendar, right-click opens stopwatch

### Button Management
- Per-button config (show/hide, scale, strata, anchor point, offset, fade-on-hover) for: zoom, mail, crafting orders, addon compartment, instance difficulty, expansion missions, calendar, tracking
- Buttons are parented to a dedicated UIParent-level holder frame so the Minimap widget's native mouse handling does not intercept clicks
- LibDBIcon addon button show-on-hover toggle
- Dungeon eye (QueueStatusButton) positioning with corner, scale, and offset controls

### Options UI
Three-tab AceConfig panel (General, Elements, Buttons) registered under `/tui minimap`.

### Files
| File | Purpose |
|---|---|
| `Minimap.lua` | Module core: lifecycle, shape, backdrop, size, dragging, zoom, strata, opacity |
| `Minimap_Elements.lua` | Zone text, coordinates, clock, button visibility/positioning, fade system, dungeon eye, tickers |
| `Minimap_Options.lua` | Full AceConfig options across three tabs |
| `Minimap.xml` | Load order manifest |
| `Modules.xml` | Added Minimap include |

## Test Plan
- [ ] `/reload` — minimap appears at default position (top-right) with square shape, black border, full opacity
- [ ] Toggle shape to round — minimap and border both render as circles, blob ring re-enabled
- [ ] Drag minimap to new position — persists across `/reload`, lock toggle prevents dragging
- [ ] Adjust strata to HIGH — minimap renders above most frames
- [ ] Set base opacity to 0.5, moving to 0.3, mounted to 0.1 — verify transitions between states
- [ ] Change zone text font — updates immediately; selecting an invalid font falls back to default without breaking subsequent changes
- [ ] Enable fade-on-hover for zone text/coords/clock — elements hide when mouse leaves minimap
- [ ] Show calendar button, click it — opens calendar (not swallowed by minimap)
- [ ] Toggle hide-addon-buttons — LibDBIcon buttons only appear on hover
- [ ] Profile switch/copy/reset — all settings refresh correctly
