### PR TITLE
fix: guard pairs(_G) iteration against forbidden tables (#52)

### DIFF
--- a/Modules/uCDM/uCDM_Keybinds.lua
+++ b/Modules/uCDM/uCDM_Keybinds.lua
@@ -119,9 +119,12 @@ local function BuildActionButtonCache()
 
     for globalName, frame in pairs(_G) do
         if type(globalName) == "string" and type(frame) == "table" and not added[frame] then
-            if type(frame.GetObjectType) == "function" then
-                local hasAction = frame.action or (frame.GetAction and type(frame.GetAction) == "function")
-                if hasAction and globalName:match("Button%d+$") then
+            local ok, hasGetObjectType = pcall(function() return type(frame.GetObjectType) == "function" end)
+            if ok and hasGetObjectType then
+                local ok2, hasAction = pcall(function()
+                    return frame.action or (frame.GetAction and type(frame.GetAction) == "function")
+                end)
+                if ok2 and hasAction and globalName:match("Button%d+$") then
                     cachedActionButtons[#cachedActionButtons + 1] = frame
                     added[frame] = true
                 end


### PR DESCRIPTION
## Summary
- `BuildActionButtonCache()` in uCDM Keybinds iterates `pairs(_G)` and accesses properties on every table in the global namespace
- In 12.1 beta some globals are forbidden tables, causing "attempted to index a forbidden table" errors (239+ occurrences)
- Wrap property accesses in `pcall` so forbidden tables are silently skipped

## Testing
- Tested on retail and beta
- Binary search isolation confirmed uCDM Keybinds as sole source of the error
- Verified no errors after fix with `/console scriptErrors 1`

## Modified Files
| File | Change |
|------|--------|
| `Modules/uCDM/uCDM_Keybinds.lua` | pcall-wrap `frame.GetObjectType`, `frame.action`, `frame.GetAction` accesses in `BuildActionButtonCache()` `pairs(_G)` loop |

Closes #52