### PR TITLE
fix: uf portrait positioning, boss position persistence, bar layout filtering (#64, #65, #71)

### DIFF
--- a/Modules/UnitFrames/UnitFrames.lua
+++ b/Modules/UnitFrames/UnitFrames.lua
@@ -84,7 +84,6 @@ local UNIT_INDICATORS = {
 module.UNIT_INDICATORS = UNIT_INDICATORS
 
 local defaults = {
-    editModeLayoutPositions = {},
     -- Theme settings (flat, read via GetThemeSetting)
     statusBarTexture = THEME_DEFAULTS.statusBarTexture,
     frameBg = THEME_DEFAULTS.frameBg,
@@ -104,6 +103,7 @@ local defaults = {
             enabled = true, width = 200, height = 40,
             showPower = true, showCastbar = true, showPortrait = false,
             showClassPower = true, showInfoBar = false,
+            portrait = { side = "LEFT" },
             useClassColor = false, rangeAlpha = 1,
             barLayout = "HP",
             themeOverrides = {},
@@ -129,6 +129,7 @@ local defaults = {
             enabled = true, width = 200, height = 40,
             showPower = true, showCastbar = true, showPortrait = false,
             showClassPower = false, showInfoBar = false,
+            portrait = { side = "RIGHT" },
             useClassColor = false, rangeAlpha = 1,
             barLayout = "HP",
             themeOverrides = {},
@@ -261,6 +262,7 @@ local defaults = {
             enabled = false, width = 200, height = 40,
             showPower = true, showCastbar = true, showPortrait = false,
             showClassPower = false, showInfoBar = false,
+            portrait = { side = "RIGHT" },
             useClassColor = false, rangeAlpha = 1,
             barLayout = "HP",
             themeOverrides = {},
@@ -674,20 +676,30 @@ function module:UpdateFrame(unit)
     if frame.TUI_InfoBarText then frame.TUI_InfoBarText:SetTextColor(tr, tg, tb, ta) end
 
     if db.showPortrait then
+        if frame.TUI_PortraitFrame then
+            local pDb = db.portrait or {}
+            local side = pDb.side or "LEFT"
+            local size = frame:GetHeight()
+            frame.TUI_PortraitFrame:SetSize(size, size)
+            frame.TUI_PortraitFrame:ClearAllPoints()
+            if side == "RIGHT" then
+                frame.TUI_PortraitFrame:SetPoint("LEFT", frame, "RIGHT", 0, 0)
+            else
+                frame.TUI_PortraitFrame:SetPoint("RIGHT", frame, "LEFT", 0, 0)
+            end
+            frame.TUI_PortraitFrame:Show()
+        end
         if not frame.Portrait and frame.TUI_Portrait then
             frame.Portrait = frame.TUI_Portrait
             frame:EnableElement("Portrait")
-        end
-        if frame.TUI_Portrait then
-            frame.TUI_Portrait:SetSize(frame:GetHeight(), frame:GetHeight())
         end
     else
         if frame.Portrait then
             frame:DisableElement("Portrait")
             frame.Portrait = nil
         end
-        if frame.TUI_Portrait then
-            frame.TUI_Portrait:Hide()
+        if frame.TUI_PortraitFrame then
+            frame.TUI_PortraitFrame:Hide()
         end
     end
 

--- a/Modules/UnitFrames/UnitFrames_Elements.lua
+++ b/Modules/UnitFrames/UnitFrames_Elements.lua
@@ -140,16 +140,31 @@ function Elements:CreatePower(frame, unit, db)
 end
 
 function Elements:CreatePortrait(frame, unit, db)
-    local portrait = frame:CreateTexture(nil, "OVERLAY")
-    portrait:SetSize(frame:GetHeight(), frame:GetHeight())
-    portrait:SetPoint("LEFT")
+    local pDb = db.portrait or {}
+    local side = pDb.side or "LEFT"
+    local size = frame:GetHeight()
+
+    local container = CreateFrame("Frame", nil, frame)
+    container:SetFrameLevel(frame:GetFrameLevel() + 4)
+    container:SetSize(size, size)
+    container:ClearAllPoints()
+    if side == "RIGHT" then
+        container:SetPoint("LEFT", frame, "RIGHT", 0, 0)
+    else
+        container:SetPoint("RIGHT", frame, "LEFT", 0, 0)
+    end
+
+    local portrait = container:CreateTexture(nil, "ARTWORK")
+    portrait:SetAllPoints()
+    portrait:SetTexCoord(0.15, 0.85, 0.15, 0.85)
 
     frame.TUI_Portrait = portrait
+    frame.TUI_PortraitFrame = container
 
     if db.showPortrait then
         frame.Portrait = portrait
     else
-        portrait:Hide()
+        container:Hide()
     end
 
     return portrait


### PR DESCRIPTION
## Summary

- Portrait renders as an external square frame anchored outside the unit frame (left or right side), with a portrait side option for player, target, and arena units
- Boss/arena frame positions persist across `/reload` by calling `SetAnchorConfig` in the LibEditMode callback and removing the snapshot revert logic that discarded changes on edit mode exit
- Bar layout dropdown now filters options based on which elements (Power, InfoBar, ClassPower) are actually enabled

## Testing

- [x] Portrait displays as square to the left of player frame, right of target/arena frames
- [x] Portrait side option toggles left/right positioning correctly
- [x] Portrait option only appears for player, target, arena unit types
- [x] Boss frame positions persist across `/reload`
- [x] Arena frame positions persist across `/reload`
- [x] Boss frames still move as a group (boss1 moves all 5)
- [x] Arena frames still move as a group (arena1 moves all 3)
- [x] Bar layout dropdown only shows valid options for enabled elements
- [x] Disabling Power correctly reduces layout options to HP-only

## Modified Files

| File | Changes |
|------|---------|
| `Modules/UnitFrames/UnitFrames.lua` | Portrait defaults (side), removed `editModeLayoutPositions` from AceDB defaults, updated `UpdateFrame` portrait logic for external container |
| `Modules/UnitFrames/UnitFrames_Anchoring.lua` | Added `SetAnchorConfig` to LibEditMode callback and nudge handler, removed snapshot/revert logic and `C_EditMode.SaveLayouts` hook |
| `Modules/UnitFrames/UnitFrames_Elements.lua` | Rewrote `CreatePortrait` with external container frame and TexCoord cropping |
| `Modules/UnitFrames/UnitFrames_Options.lua` | Added portrait side option, portrait visibility filter, bar layout dynamic filtering |

## New Files

None

## Libraries

No library changes.

## Settings

| Setting | Type | Description |
|---------|------|-------------|
| `portrait.side` | select | LEFT or RIGHT positioning for portrait (player, target, arena) |

Closes #64, #65, #71