### PR TITLE
fix: add reentrancy guard to QoL SetParent hook (#83)

### DIFF
--- a/Modules/QoL/QoL.lua
+++ b/Modules/QoL/QoL.lua
@@ -219,13 +219,17 @@ function module:ApplyFrameHider()
     if hide then
         if not self.playerFrameSetParentHook then
             self.playerFrameSetParentHook = true
+            local reparenting = false
             hooksecurefunc(PlayerFrame, "SetParent", function(frame, parent)
+                if reparenting then return end
                 if parent ~= module.playerFrameHiddenParent and module:IsEnabled() and module:GetSetting("hidePlayerFrame", false) then
                     if InCombatLockdown() and frame:IsProtected() then
                         module.pendingFrameHiderApply = true
                         module:RegisterEvent("PLAYER_REGEN_ENABLED", "ApplyFrameHiderDeferred")
                     else
+                        reparenting = true
                         frame:SetParent(module.playerFrameHiddenParent)
+                        reparenting = false
                     end
                 end
             end)


### PR DESCRIPTION
## Summary
- Fixed C stack overflow caused by infinite recursion between QoL and oUF SetParent hooks on PlayerFrame
- Added reentrancy guard flag to prevent QoL's hook from re-triggering when oUF's hook fires

## Testing
- Tested on retail, toggling Hide Player Frame on/off with no stack overflow

## Modified Files
| File | Change |
|------|--------|
| `Modules/QoL/QoL.lua` | Added `reparenting` guard around `SetParent` call in hook |

Closes #83