### PR TITLE
fix: check parent module enabled state in uCDM viewer visibility (#79)

### DIFF
--- a/Modules/uCDM/uCDM_LayoutEngine.lua
+++ b/Modules/uCDM/uCDM_LayoutEngine.lua
@@ -536,6 +536,10 @@ end
 function LayoutEngine.ApplyVisibilityToViewer(viewerKey, deferInHookContext)
     local viewer = module:GetViewerFrame(viewerKey)
     if not viewer then return end
+    if not module:IsEnabled() then
+        viewer:Hide()
+        return
+    end
     local settings = module:GetViewerSettings(viewerKey)
     if not settings or settings.enabled == false then
         viewer:Hide()
@@ -605,6 +609,12 @@ function LayoutEngine.RefreshViewer(viewerKey, skipDebounce)
 
     local viewer = module:GetViewerFrame(viewerKey)
     if not viewer then
+        done()
+        return
+    end
+
+    if not module:IsEnabled() then
+        viewer:Hide()
         done()
         return
     end


### PR DESCRIPTION
## Summary
- Fixed uCDM viewers (Essential, Utility, Buff) reappearing after parent module is disabled
- Added `module:IsEnabled()` guard to `ApplyVisibilityToViewer` and `RefreshViewer` in LayoutEngine

## Testing
- Tested on retail, disabling uCDM module and verifying all viewers stay hidden

## Modified Files
| File | Change |
|------|--------|
| `Modules/uCDM/uCDM_LayoutEngine.lua` | Added parent module enabled check to `ApplyVisibilityToViewer` and `RefreshViewer` |

Closes #79