### PR TITLE
fix: sell junk not blocked by repair guard (#113)

### DIFF
--- a/Modules/QoL/QoL.lua
+++ b/Modules/QoL/QoL.lua
@@ -247,16 +247,13 @@ function module:ApplyFrameHiderDeferred()
 end
 
 function module:OnMerchantShow()
-    if not CanMerchantRepair() then
-        return
-    end
-    if self:GetSetting("autoRepair", true) then
+    if self:GetSetting("autoRepair", true) and CanMerchantRepair() then
         self:DoAutoRepair()
     end
     if self:GetSetting("autoSellJunk", true) then
         self:SellJunk()
+        self:RegisterEvent("BAG_UPDATE_DELAYED", "OnBagUpdateDelayed")
     end
-    self:RegisterEvent("BAG_UPDATE_DELAYED", "OnBagUpdateDelayed")
 end
 
 function module:OnMerchantClosed()


### PR DESCRIPTION
## Summary
- Fix sell junk not running when merchant cannot repair
- Move `CanMerchantRepair()` check into the autoRepair conditional so sell junk runs independently
- Register `BAG_UPDATE_DELAYED` only when actually selling junk

## Testing
- Tested on retail at merchants that cannot repair (e.g. reagent vendors)
- Verified junk sells correctly regardless of repair capability
- Verified auto repair still works at repair-capable merchants

## Modified Files
| File | Change |
|------|--------|
| `Modules/QoL/QoL.lua` | Move CanMerchantRepair into autoRepair branch, scope BAG_UPDATE_DELAYED to sell junk |

Closes #113