### PR TITLE
fix: delegate TUI tags to oUF built-ins, fix perhp secret value crash (#174)

### DIFF
--- a/Modules/UnitFrames/UnitFrames_Options.lua
+++ b/Modules/UnitFrames/UnitFrames_Options.lua
@@ -255,7 +255,6 @@ local function BuildTagReference()
                 type = "description",
                 name = "Color tags output |cff hex codes. Place before text and add |r after to end the color.\n\n"
                     .. "|cffffd200[TUI:classcolor]|r  Class color (Warrior brown, Mage blue, etc.)\n"
-                    .. "|cffffd200[TUI:reactioncolor]|r  Reaction color (friendly green, hostile red)\n"
                     .. "|cffffd200[TUI:diffcolor]|r  Difficulty color based on level difference\n",
                 order = 51,
                 fontSize = "medium",

--- a/Modules/UnitFrames/UnitFrames_Tags.lua
+++ b/Modules/UnitFrames/UnitFrames_Tags.lua
@@ -2,7 +2,6 @@ local TavernUI = LibStub("AceAddon-3.0"):GetAddon("TavernUI")
 local oUF = TavernUI.oUF
 if not oUF then return end
 
-local floor = math.floor
 local format = string.format
 local sub = string.sub
 
@@ -10,38 +9,30 @@ local UnitName = UnitName
 local UnitHealth = UnitHealth
 local UnitHealthMax = UnitHealthMax
 local UnitPower = UnitPower
-local UnitPowerMax = UnitPowerMax
 local UnitClass = UnitClass
 local UnitRace = UnitRace
-local UnitLevel = UnitLevel
 local UnitEffectiveLevel = UnitEffectiveLevel
-local UnitClassification = UnitClassification
-local UnitIsDeadOrGhost = UnitIsDeadOrGhost
-local UnitIsGhost = UnitIsGhost
-local UnitIsConnected = UnitIsConnected
 local UnitIsAFK = UnitIsAFK
-local IsResting = IsResting
-local UnitReaction = UnitReaction
-local UnitGroupRolesAssigned = UnitGroupRolesAssigned
-local GetNumGroupMembers = GetNumGroupMembers
-local GetRaidRosterInfo = GetRaidRosterInfo
 local GetCreatureDifficultyColor = GetCreatureDifficultyColor
 local canaccessvalue = canaccessvalue
-local issecretvalue = issecretvalue
-
-local RAID_CLASS_COLORS = RAID_CLASS_COLORS
 
 local function ShortValue(val)
     return AbbreviateLargeNumbers(val)
+end
+
+-- Delegate a TUI:tag to an oUF built-in tag, preserving user-facing tag names.
+-- oUF.Tags.Methods lazily compiles built-in tag strings on first access.
+local function delegate(tag)
+    return function(unit, realUnit)
+        return oUF.Tags.Methods[tag](unit, realUnit)
+    end
 end
 
 -- ============================================================================
 -- Identity Tags
 -- ============================================================================
 
-oUF.Tags.Methods["TUI:name"] = function(unit)
-    return UnitName(unit)
-end
+oUF.Tags.Methods["TUI:name"] = delegate("name")
 oUF.Tags.Events["TUI:name"] = "UNIT_NAME_UPDATE"
 
 oUF.Tags.Methods["TUI:name:short"] = function(unit)
@@ -68,66 +59,20 @@ end
 oUF.Tags.Events["TUI:race"] = "UNIT_NAME_UPDATE"
 
 oUF.Tags.Methods["TUI:class"] = function(unit)
-    local class = UnitClass(unit)
-    return class
+    return UnitClass(unit)
 end
 oUF.Tags.Events["TUI:class"] = "UNIT_NAME_UPDATE"
 
-oUF.Tags.Methods["TUI:level"] = function(unit)
-    local level = UnitEffectiveLevel(unit)
-    if not level or level <= 0 then
-        return "??"
-    end
-    return tostring(level)
-end
+oUF.Tags.Methods["TUI:level"] = delegate("level")
 oUF.Tags.Events["TUI:level"] = "UNIT_LEVEL PLAYER_LEVEL_UP"
 
-oUF.Tags.Methods["TUI:smartlevel"] = function(unit)
-    local level = UnitEffectiveLevel(unit)
-    if not level or level <= 0 then
-        return "??"
-    end
-    local c = UnitClassification(unit)
-    if c == "worldboss" or c == "boss" then
-        return "Boss"
-    elseif c == "rareelite" then
-        return level .. "r+"
-    elseif c == "elite" then
-        return level .. "+"
-    elseif c == "rare" then
-        return level .. "r"
-    end
-    return tostring(level)
-end
+oUF.Tags.Methods["TUI:smartlevel"] = delegate("smartlevel")
 oUF.Tags.Events["TUI:smartlevel"] = "UNIT_LEVEL PLAYER_LEVEL_UP UNIT_CLASSIFICATION_CHANGED"
 
-oUF.Tags.Methods["TUI:classification"] = function(unit)
-    local c = UnitClassification(unit)
-    if c == "worldboss" or c == "boss" then
-        return "Boss"
-    elseif c == "rareelite" then
-        return "Rare Elite"
-    elseif c == "elite" then
-        return "Elite"
-    elseif c == "rare" then
-        return "Rare"
-    end
-    return nil
-end
+oUF.Tags.Methods["TUI:classification"] = delegate("classification")
 oUF.Tags.Events["TUI:classification"] = "UNIT_CLASSIFICATION_CHANGED"
 
-oUF.Tags.Methods["TUI:group"] = function(unit)
-    local name, realm = UnitName(unit)
-    if not name then return nil end
-    local nameRealm = realm and realm ~= "" and (name .. "-" .. realm) or name
-    for i = 1, GetNumGroupMembers() do
-        local raidName, _, subgroup = GetRaidRosterInfo(i)
-        if raidName == nameRealm or raidName == name then
-            return tostring(subgroup)
-        end
-    end
-    return nil
-end
+oUF.Tags.Methods["TUI:group"] = delegate("group")
 oUF.Tags.Events["TUI:group"] = "GROUP_ROSTER_UPDATE"
 oUF.Tags.SharedEvents.GROUP_ROSTER_UPDATE = true
 
@@ -135,48 +80,26 @@ oUF.Tags.SharedEvents.GROUP_ROSTER_UPDATE = true
 -- Health Tags
 -- ============================================================================
 
-oUF.Tags.Methods["TUI:curhp"] = function(unit)
-    return UnitHealth(unit)
-end
+oUF.Tags.Methods["TUI:curhp"] = delegate("curhp")
 oUF.Tags.Events["TUI:curhp"] = "UNIT_HEALTH UNIT_MAXHEALTH"
 
-oUF.Tags.Methods["TUI:maxhp"] = function(unit)
-    return UnitHealthMax(unit)
-end
+oUF.Tags.Methods["TUI:maxhp"] = delegate("maxhp")
 oUF.Tags.Events["TUI:maxhp"] = "UNIT_HEALTH UNIT_MAXHEALTH"
 
-oUF.Tags.Methods["TUI:perhp"] = function(unit)
-    local cur = UnitHealth(unit)
-    local max = UnitHealthMax(unit)
-    if not canaccessvalue(cur) or not canaccessvalue(max) then
-        return nil
-    end
-    if max == 0 then return "0" end
-    return format("%d", (cur / max) * 100)
-end
+-- oUF's perhp uses UnitHealthPercent which is secret-value safe
+oUF.Tags.Methods["TUI:perhp"] = delegate("perhp")
 oUF.Tags.Events["TUI:perhp"] = "UNIT_HEALTH UNIT_MAXHEALTH"
 
-oUF.Tags.Methods["TUI:deficit:hp"] = function(unit)
-    local cur = UnitHealth(unit)
-    local max = UnitHealthMax(unit)
-    if not canaccessvalue(cur) or not canaccessvalue(max) then return nil end
-    local deficit = max - cur
-    if deficit > 0 then
-        return "-" .. ShortValue(deficit)
-    end
-    return nil
-end
+oUF.Tags.Methods["TUI:deficit:hp"] = delegate("missinghp")
 oUF.Tags.Events["TUI:deficit:hp"] = "UNIT_HEALTH UNIT_MAXHEALTH"
 
 oUF.Tags.Methods["TUI:curhp:short"] = function(unit)
-    local cur = UnitHealth(unit)
-    return ShortValue(cur)
+    return ShortValue(UnitHealth(unit))
 end
 oUF.Tags.Events["TUI:curhp:short"] = "UNIT_HEALTH UNIT_MAXHEALTH"
 
 oUF.Tags.Methods["TUI:maxhp:short"] = function(unit)
-    local max = UnitHealthMax(unit)
-    return ShortValue(max)
+    return ShortValue(UnitHealthMax(unit))
 end
 oUF.Tags.Events["TUI:maxhp:short"] = "UNIT_HEALTH UNIT_MAXHEALTH"
 
@@ -184,36 +107,23 @@ oUF.Tags.Events["TUI:maxhp:short"] = "UNIT_HEALTH UNIT_MAXHEALTH"
 -- Power Tags
 -- ============================================================================
 
-oUF.Tags.Methods["TUI:curpp"] = function(unit)
-    return UnitPower(unit)
-end
+oUF.Tags.Methods["TUI:curpp"] = delegate("curpp")
 oUF.Tags.Events["TUI:curpp"] = "UNIT_POWER_UPDATE UNIT_MAXPOWER"
 
-oUF.Tags.Methods["TUI:maxpp"] = function(unit)
-    return UnitPowerMax(unit)
-end
+oUF.Tags.Methods["TUI:maxpp"] = delegate("maxpp")
 oUF.Tags.Events["TUI:maxpp"] = "UNIT_POWER_UPDATE UNIT_MAXPOWER"
 
-oUF.Tags.Methods["TUI:perpp"] = function(unit)
-    local max = UnitPowerMax(unit)
-    local cur = UnitPower(unit)
-    if not canaccessvalue(cur) or not canaccessvalue(max) then
-        return cur
-    end
-    if max == 0 then return "0" end
-    return format("%d", (cur / max) * 100)
-end
+-- oUF's perpp uses UnitPowerPercent which is secret-value safe
+oUF.Tags.Methods["TUI:perpp"] = delegate("perpp")
 oUF.Tags.Events["TUI:perpp"] = "UNIT_POWER_UPDATE UNIT_MAXPOWER"
 
 oUF.Tags.Methods["TUI:curpp:short"] = function(unit)
-    local cur = UnitPower(unit)
-    return ShortValue(cur)
+    return ShortValue(UnitPower(unit))
 end
 oUF.Tags.Events["TUI:curpp:short"] = "UNIT_POWER_UPDATE UNIT_MAXPOWER"
 
 oUF.Tags.Methods["TUI:curmana"] = function(unit)
-    local mana = UnitPower(unit, Enum.PowerType.Mana)
-    return ShortValue(mana)
+    return ShortValue(UnitPower(unit, Enum.PowerType.Mana))
 end
 oUF.Tags.Events["TUI:curmana"] = "UNIT_POWER_UPDATE UNIT_MAXPOWER"
 
@@ -221,28 +131,14 @@ oUF.Tags.Events["TUI:curmana"] = "UNIT_POWER_UPDATE UNIT_MAXPOWER"
 -- Status Tags
 -- ============================================================================
 
-oUF.Tags.Methods["TUI:dead"] = function(unit)
-    if UnitIsGhost(unit) then return "Ghost" end
-    if UnitIsDeadOrGhost(unit) then return "Dead" end
-    return nil
-end
+oUF.Tags.Methods["TUI:dead"] = delegate("dead")
 oUF.Tags.Events["TUI:dead"] = "UNIT_HEALTH"
 
-oUF.Tags.Methods["TUI:offline"] = function(unit)
-    if not UnitIsConnected(unit) then return "Offline" end
-    return nil
-end
+oUF.Tags.Methods["TUI:offline"] = delegate("offline")
 oUF.Tags.Events["TUI:offline"] = "UNIT_CONNECTION"
 
-oUF.Tags.Methods["TUI:status"] = function(unit)
-    if not UnitIsConnected(unit) then return "Offline" end
-    if UnitIsGhost(unit) then return "Ghost" end
-    if UnitIsDeadOrGhost(unit) then return "Dead" end
-    if unit == "player" and IsResting() then return "zzz" end
-    return nil
-end
+oUF.Tags.Methods["TUI:status"] = delegate("status")
 oUF.Tags.Events["TUI:status"] = "UNIT_HEALTH UNIT_CONNECTION PLAYER_UPDATE_RESTING"
-oUF.Tags.SharedEvents.PLAYER_UPDATE_RESTING = true
 
 oUF.Tags.Methods["TUI:afk"] = function(unit)
     if UnitIsAFK(unit) then return "AFK" end
@@ -250,40 +146,15 @@ oUF.Tags.Methods["TUI:afk"] = function(unit)
 end
 oUF.Tags.Events["TUI:afk"] = "PLAYER_FLAGS_CHANGED"
 
-oUF.Tags.Methods["TUI:resting"] = function(unit)
-    if unit == "player" and IsResting() then return "zzz" end
-    return nil
-end
+oUF.Tags.Methods["TUI:resting"] = delegate("resting")
 oUF.Tags.Events["TUI:resting"] = "PLAYER_UPDATE_RESTING"
 
 -- ============================================================================
 -- Color Tags (return |cff hex codes)
 -- ============================================================================
 
-oUF.Tags.Methods["TUI:classcolor"] = function(unit)
-    local _, class = UnitClass(unit)
-    if class then
-        local color = RAID_CLASS_COLORS[class]
-        if color then
-            return format("|cff%02x%02x%02x", color.r * 255, color.g * 255, color.b * 255)
-        end
-    end
-    return "|cffffffff"
-end
+oUF.Tags.Methods["TUI:classcolor"] = delegate("raidcolor")
 oUF.Tags.Events["TUI:classcolor"] = "UNIT_NAME_UPDATE"
-
-oUF.Tags.Methods["TUI:reactioncolor"] = function(unit)
-    local reaction = UnitReaction(unit, "player")
-    if reaction then
-        local colors = oUF.colors.reaction
-        if colors and colors[reaction] then
-            local c = colors[reaction]
-            return format("|cff%02x%02x%02x", c[1] * 255, c[2] * 255, c[3] * 255)
-        end
-    end
-    return "|cffffffff"
-end
-oUF.Tags.Events["TUI:reactioncolor"] = "UNIT_FACTION"
 
 oUF.Tags.Methods["TUI:diffcolor"] = function(unit)
     local level = UnitEffectiveLevel(unit)


### PR DESCRIPTION
## Summary
- Fix [TUI:perhp] and [TUI:perpp] showing nothing — both were doing arithmetic on secret values (UnitHealth/UnitPower); now delegate to oUF's built-ins which use UnitHealthPercent/UnitPowerPercent
- Fix [TUI:deficit:hp] with same root cause; delegate to oUF missinghp which uses UnitHealthMissing
- Delegate 14 additional TUI tags that duplicated oUF built-ins to their oUF equivalents, reducing maintenance surface
- Remove unused TUI:reactioncolor tag

## Testing
- Tested on retail (Midnight 12.0)
- Verified [TUI:perhp] displays correctly on player, target, and focus frames
- Verified [TUI:perpp], [TUI:curhp], [TUI:name] and other delegated tags display correctly

## Modified Files
| File | Change |
|------|--------|
| `Modules/UnitFrames/UnitFrames_Tags.lua` | Delegate 17 TUI tags to oUF built-ins; remove TUI:reactioncolor |
| `Modules/UnitFrames/UnitFrames_Options.lua` | Remove TUI:reactioncolor from tag reference help text |

Closes #174