### PR TITLE
fix: uCDM keybinds not shown on ElvUI action bar buttons

### DIFF
--- a/Modules/uCDM/uCDM_Keybinds.lua
+++ b/Modules/uCDM/uCDM_Keybinds.lua
@@ -76,9 +76,15 @@ local function IsValidActionButton(button)
     local hasAction = false
     if type(button.action) == "number" and button.action > 0 then
         hasAction = true
+    elseif type(button._state_action) == "number" and button._state_action > 0 then
+        -- LAB (ElvUI, BT4) sets _state_action in UpdateAction(); button.action may still be 0 at cache time
+        hasAction = true
     elseif button.GetAction and type(button.GetAction) == "function" then
-        local action = button:GetAction()
-        if type(action) == "number" and action > 0 then
+        local retA, retB = button:GetAction()
+        -- LAB returns (type_string, slot_number); Blizzard returns a single number
+        local action = (type(retB) == "number" and retB > 0 and retB) or
+                       (type(retA) == "number" and retA > 0 and retA)
+        if action then
             hasAction = true
         end
     end
@@ -168,7 +174,7 @@ local function GetActionSlot(button)
     local action
     local buttonName = button.GetName and button:GetName()
 
-    if buttonName and buttonName:match("^BT4Button") then
+    if buttonName and (buttonName:match("^BT4Button") or buttonName:match("^ElvUI_Bar")) then
         if type(button._state_action) == "number" and button._state_action > 0 then
             action = button._state_action
         end
@@ -181,8 +187,13 @@ local function GetActionSlot(button)
     end
 
     if (not action or action == 0) and button.GetAction and type(button.GetAction) == "function" then
-        action = button:GetAction()
-        if type(action) ~= "number" or action <= 0 then
+        local retA, retB = button:GetAction()
+        -- LAB returns (type_string, slot_number); Blizzard returns a single number
+        if type(retB) == "number" and retB > 0 then
+            action = retB
+        elseif type(retA) == "number" and retA > 0 then
+            action = retA
+        else
             action = nil
         end
     end
@@ -531,6 +542,7 @@ function Keybinds.Initialize()
         end
 
         if event == "UPDATE_BINDINGS" then
+            actionButtonsCached = false  -- Force rediscovery; third-party bars (e.g. ElvUI) may not be ready at PLAYER_ENTERING_WORLD+0.5s
             ThrottledRebuild()
             return
         end


### PR DESCRIPTION
Fixes #124

## Root Cause

LibActionButton (LAB), used by both ElvUI and Bartender4, initialises `button.action = 0` at creation. It only sets the real slot value inside `UpdateAction()`. At `PLAYER_ENTERING_WORLD + 0.5s` TavernUI caches action bar buttons, but ElvUI's LAB hasn't called `UpdateAction()` yet — every ElvUI button has `action = 0` and is rejected by `IsValidActionButton`. ElvUI then fires `UPDATE_BINDINGS` once its bars are ready, but the handler didn't reset `actionButtonsCached`, so `BuildActionButtonCache()` returned early and ElvUI bars were never discovered.

Secondary bug: `GetAction()` on LAB buttons returns two values `(type_string, slot_number)`. The old code captured only the first return (a string), which failed the `type(action) ~= "number"` guard, silently discarding valid slots.

## Changes

| Location | Change |
|---|---|
| `IsValidActionButton` | Check `_state_action` before `GetAction()` fallback — accepts LAB buttons whose `action` is still `0` at cache time |
| `IsValidActionButton` / `GetActionSlot` | Capture both return values from `GetAction()` — LAB returns `(type_string, slot_number)` |
| `GetActionSlot` | Extend `_state_action` fast-path to `ElvUI_Bar*` buttons (was BT4-only) |
| `UPDATE_BINDINGS` handler | Reset `actionButtonsCached = false` so the full button scan re-runs when third-party bars signal readiness |

## Behaviour After Fix

| Scenario | Before | After |
|---|---|---|
| ElvUI bars at login | Buttons missed (`action=0` at 0.5s cache) | `UPDATE_BINDINGS` triggers full rescan ✓ |
| ElvUI bar keybinds | Never shown | Discovered after ElvUI signals ready ✓ |
| BT4 / Blizzard bars | Unchanged ✓ | Unchanged ✓ |
| Rebind a key | Values refresh only | Values refresh + full rescan ✓ |

## Test Plan

- [ ] Load game with ElvUI enabled — keybinds appear on uCDM icons after ElvUI finishes initialising
- [ ] Rebind a key in WoW keybind settings — updated keybind reflects on cooldown icon
- [ ] Blizzard/BT4/Dominos keybinds still display correctly (no regression)
- [ ] `/reload` with no ElvUI — no errors, normal keybinds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)